### PR TITLE
Expose concrete WKB type in public API

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -81,18 +81,18 @@ impl From<WKBDimension> for geo_traits::Dimensions {
 /// In extended WKB this additionally informs whether there's a u32 SRID immediately after this,
 /// which we need to know to skip.
 #[repr(transparent)]
-pub struct WKBGeometryCode(u32);
+pub(crate) struct WKBGeometryCode(u32);
 
 impl WKBGeometryCode {
-    pub fn new(code: u32) -> Self {
+    pub(crate) fn new(code: u32) -> Self {
         Self(code)
     }
 
-    pub fn has_srid(&self) -> bool {
+    pub(crate) fn has_srid(&self) -> bool {
         self.0 & EWKB_FLAG_SRID == EWKB_FLAG_SRID
     }
 
-    pub fn get_type(&self) -> WKBResult<WKBType> {
+    pub(crate) fn get_type(&self) -> WKBResult<WKBType> {
         let code = self.0;
         let mut dim = WKBDimension::Xy;
 
@@ -159,7 +159,7 @@ pub enum WKBType {
 
 impl WKBType {
     /// Construct from a byte slice representing a WKB geometry
-    pub fn from_buffer(buf: &[u8]) -> WKBResult<Self> {
+    pub(crate) fn from_buffer(buf: &[u8]) -> WKBResult<Self> {
         let mut reader = Cursor::new(buf);
         let byte_order = reader.read_u8().unwrap();
         let geometry_code = match byte_order {
@@ -175,7 +175,7 @@ impl WKBType {
         WKBGeometryCode(geometry_code).get_type()
     }
 
-    pub fn as_geometry_code(&self) -> WKBGeometryCode {
+    pub(crate) fn as_geometry_code(&self) -> WKBGeometryCode {
         let code = match self {
             Self::Point(dim) => 1 + dim.as_u32_offset(),
             Self::LineString(dim) => 2 + dim.as_u32_offset(),

--- a/src/reader/geometry_collection.rs
+++ b/src/reader/geometry_collection.rs
@@ -2,8 +2,8 @@ use std::io::Cursor;
 
 use crate::common::WKBDimension;
 use crate::error::WKBResult;
-use crate::reader::geometry::Wkb;
 use crate::reader::util::{has_srid, ReadBytesExt};
+use crate::reader::Wkb;
 use crate::Endianness;
 use geo_traits::{Dimensions, GeometryCollectionTrait};
 

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -15,7 +15,7 @@ mod point;
 mod polygon;
 mod util;
 
-use geometry::Wkb;
+pub use geometry::Wkb;
 use geometry_collection::GeometryCollection;
 use linestring::LineString;
 use multilinestring::MultiLineString;
@@ -24,28 +24,11 @@ use multipolygon::MultiPolygon;
 use point::Point;
 use polygon::Polygon;
 
-use geo_traits::GeometryTrait;
-
 use crate::error::WKBResult;
 
 /// Parse a WKB byte slice into a geometry.
 ///
-/// This returns an opaque object that implements [`GeometryTrait`]. Use methods provided by
-/// [`geo_traits`] to access the underlying data.
-///
-/// The contained [dimension][geo_traits::Dimensions] will never be `Unknown`.
-///
-/// ### Performance
-///
-/// WKB is not a zero-copy format because coordinates are not 8-byte aligned and because an initial
-/// scan needs to take place to know internal buffer offsets.
-///
-/// This function does an initial pass over the WKB buffer to validate the contents and record the
-/// byte offsets for relevant coordinate slices but does not copy the underlying data to an
-/// alternate representation. This means that coordinates will **always be constant-time to
-/// access** but **not zero-copy**. This is because the raw WKB buffer is not 8-byte aligned, so
-/// when accessing a coordinate the underlying bytes need to be copied into a newly-allocated
-/// `f64`.
-pub fn read_wkb(buf: &[u8]) -> WKBResult<impl GeometryTrait<T = f64> + use<'_>> {
+/// This is an alias for [`Wkb::try_new`].
+pub fn read_wkb(buf: &[u8]) -> WKBResult<Wkb> {
     Wkb::try_new(buf)
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
- [x] I ran cargo fmt
---

Currently in v0.8 there are [no exported structs](https://docs.rs/wkb/0.8.0/wkb/reader/index.html). There's only a function `read_wkb` that returns an opaque `impl GeometryTrait` type. This is "elegant" as it exposes a minimal public API but I've found that not having a concrete type can also be limiting.

In particular, in a geoarrow refactor, I was thinking of having a trait like:

```rs
pub trait ArrayAccessor<'a>: ArrayBase {
    /// The scalar object for this geometry array type.
    type Item: Send + Sync + GeometryTrait<T = f64>;
```

Where this would need to be applied to a GeoArrow `WKBArray`. But this isn't possible in the current `wkb` API because there's no public type to go into the `Item` associated type.

**This is not a breaking change**. All diffs in this PR of changing `pub` to `pub(crate)` are of methods that were not (and mostly are still not) exported publicly. 

This **only** exposes the `Wkb` type and a `try_new` constructor. Still, the only exposed methods are via `geo_traits`.

This also supports https://github.com/georust/wkb/issues/52, as we could add an `srid(&self) -> Option<u32>` method to `Wkb`.