### PR TITLE
Bump geos version to fix tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ approx = "0.5.1"
 bytes = "1.5.0"
 criterion = { version = "0.5", features = ["html_reports"] }
 geo-types = "0.7.13"
-geos = { version = "9.1.0", features = ["geo"] }
+geos = { version = "10", features = ["geo"] }
 wkt = "0.12"
 
 [[bench]]


### PR DESCRIPTION
- [ ] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
- [ ] I ran cargo fmt
---

geos v9 was yanked.