### PR TITLE
Fix lifetime annotations for various implementations of geo traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Your change here.
 - Expose `wkb::reader::Wkb` type through public API.
-- Making lifetime annotations of `Wkb` more permissive.
+- Make lifetime annotations of `Wkb` more permissive. (#59)
 
 ## 0.8.0 - 2024-12-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Your change here.
 - Expose `wkb::reader::Wkb` type through public API.
+- Making lifetime annotations of `Wkb` more permissive.
 
 ## 0.8.0 - 2024-12-03
 

--- a/src/reader/geometry.rs
+++ b/src/reader/geometry.rs
@@ -180,7 +180,7 @@ impl<'a> GeometryTrait for Wkb<'a> {
     }
 }
 
-impl<'a> GeometryTrait for &'a Wkb<'a> {
+impl<'a> GeometryTrait for &Wkb<'a> {
     type T = f64;
     type PointType<'b>
         = Point<'a>

--- a/src/reader/geometry_collection.rs
+++ b/src/reader/geometry_collection.rs
@@ -69,10 +69,10 @@ impl<'a> GeometryCollection<'a> {
     }
 }
 
-impl GeometryCollectionTrait for GeometryCollection<'_> {
+impl<'a> GeometryCollectionTrait for GeometryCollection<'a> {
     type T = f64;
     type GeometryType<'b>
-        = &'b Wkb<'b>
+        = &'b Wkb<'a>
     where
         Self: 'b;
 

--- a/src/reader/linestring.rs
+++ b/src/reader/linestring.rs
@@ -98,7 +98,7 @@ impl<'a> LineStringTrait for LineString<'a> {
     }
 }
 
-impl<'a> LineStringTrait for &'a LineString<'a> {
+impl<'a> LineStringTrait for &LineString<'a> {
     type T = f64;
     type CoordType<'b>
         = Coord<'a>

--- a/src/reader/multilinestring.rs
+++ b/src/reader/multilinestring.rs
@@ -96,7 +96,7 @@ impl<'a> MultiLineStringTrait for MultiLineString<'a> {
     }
 }
 
-impl<'a> MultiLineStringTrait for &'a MultiLineString<'a> {
+impl<'a> MultiLineStringTrait for &MultiLineString<'a> {
     type T = f64;
     type LineStringType<'b>
         = LineString<'a>

--- a/src/reader/multipoint.rs
+++ b/src/reader/multipoint.rs
@@ -100,7 +100,7 @@ impl<'a> MultiPointTrait for MultiPoint<'a> {
     }
 }
 
-impl<'a> MultiPointTrait for &'a MultiPoint<'a> {
+impl<'a> MultiPointTrait for &MultiPoint<'a> {
     type T = f64;
     type PointType<'b>
         = Point<'a>

--- a/src/reader/multipolygon.rs
+++ b/src/reader/multipolygon.rs
@@ -95,7 +95,7 @@ impl<'a> MultiPolygonTrait for MultiPolygon<'a> {
     }
 }
 
-impl<'a> MultiPolygonTrait for &'a MultiPolygon<'a> {
+impl<'a> MultiPolygonTrait for &MultiPolygon<'a> {
     type T = f64;
     type PolygonType<'b>
         = Polygon<'a>

--- a/src/reader/polygon.rs
+++ b/src/reader/polygon.rs
@@ -107,7 +107,7 @@ impl<'a> PolygonTrait for Polygon<'a> {
     }
 }
 
-impl<'a> PolygonTrait for &'a Polygon<'a> {
+impl<'a> PolygonTrait for &Polygon<'a> {
     type T = f64;
     type RingType<'b>
         = WKBLinearRing<'a>


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
- [x] I ran cargo fmt
---

I found that the lifetime annotations of various geo-traits implementations for WKB geometry types are unnecessarily restrictive. For instance:

```rust
fn lifetime() {
    let buf = vec![
        1,                      // little endian byte order
        1, 0, 0, 0,             // wkbPoint (type 1)
        0, 0, 0, 0, 0, 0, 240, 63, // X coordinate (1.0)
        0, 0, 0, 0, 0, 0, 0, 64,   // Y coordinate (2.0)
    ];

    let coord;
    {
        let wkb = read_wkb(&buf).unwrap();
        let wkb_ref = &wkb;
        let wkb_ref_ref = &&wkb_ref;
        match wkb_ref_ref.as_type() {
            geo_traits::GeometryType::LineString(line_string) => {
                coord = line_string.coord(0);
            }
            _ => {
                panic!("Expected LineString");
            }
        }
    };

    assert!(coord.is_some());
    assert_eq!(coord.unwrap().x(), 1.0);
    assert_eq!(coord.unwrap().y(), 2.0);
}
```
 
fails to compile. `coord` should be valid since the buffer it references is still alive, but the restrictive lifetime annotation prevents us from doing this:

```
error[E0597]: `wkb` does not live long enough
   --> src/test/wkb.rs:159:23
    |
158 |         let wkb = read_wkb(&buf).unwrap();
    |             --- binding `wkb` declared here
159 |         let wkb_ref = &wkb;
    |                       ^^^^ borrowed value does not live long enough
...
169 |     };
    |     - `wkb` dropped here while still borrowed
170 |
171 |     assert!(coord.is_some());
    |             ----- borrow later used here
```

This patch fixes this problem by changing various lifetime annotations to more relaxed form.