### PR TITLE
Define associated types as references for MultiLineString, Polygon and MultiPolygon

### DIFF
--- a/src/reader/linearring.rs
+++ b/src/reader/linearring.rs
@@ -91,3 +91,30 @@ impl<'a> LineStringTrait for WKBLinearRing<'a> {
         )
     }
 }
+
+impl<'a> LineStringTrait for &WKBLinearRing<'a> {
+    type T = f64;
+    type CoordType<'c>
+        = Coord<'a>
+    where
+        Self: 'c;
+
+    fn dim(&self) -> Dimensions {
+        self.dim.into()
+    }
+
+    #[inline]
+    fn num_coords(&self) -> usize {
+        self.num_points
+    }
+
+    #[inline]
+    unsafe fn coord_unchecked(&self, i: usize) -> Self::CoordType<'_> {
+        Coord::new(
+            self.buf,
+            self.byte_order,
+            self.coord_offset(i.try_into().unwrap()),
+            self.dim,
+        )
+    }
+}

--- a/src/reader/multilinestring.rs
+++ b/src/reader/multilinestring.rs
@@ -96,12 +96,12 @@ impl<'a> MultiLineStringTrait for MultiLineString<'a> {
     }
 }
 
-impl<'a> MultiLineStringTrait for &MultiLineString<'a> {
+impl<'a, 'b> MultiLineStringTrait for &'b MultiLineString<'a> {
     type T = f64;
-    type LineStringType<'b>
-        = LineString<'a>
+    type LineStringType<'c>
+        = &'b LineString<'a>
     where
-        Self: 'b;
+        Self: 'c;
 
     fn dim(&self) -> Dimensions {
         self.dim.into()
@@ -112,6 +112,6 @@ impl<'a> MultiLineStringTrait for &MultiLineString<'a> {
     }
 
     unsafe fn line_string_unchecked(&self, i: usize) -> Self::LineStringType<'_> {
-        *self.wkb_line_strings.get_unchecked(i)
+        self.wkb_line_strings.get_unchecked(i)
     }
 }

--- a/src/reader/multipolygon.rs
+++ b/src/reader/multipolygon.rs
@@ -78,7 +78,7 @@ impl<'a> MultiPolygon<'a> {
 impl<'a> MultiPolygonTrait for MultiPolygon<'a> {
     type T = f64;
     type PolygonType<'b>
-        = Polygon<'a>
+        = &'b Polygon<'a>
     where
         Self: 'b;
 
@@ -91,16 +91,16 @@ impl<'a> MultiPolygonTrait for MultiPolygon<'a> {
     }
 
     unsafe fn polygon_unchecked(&self, i: usize) -> Self::PolygonType<'_> {
-        self.wkb_polygons.get_unchecked(i).clone()
+        self.wkb_polygons.get_unchecked(i)
     }
 }
 
-impl<'a> MultiPolygonTrait for &MultiPolygon<'a> {
+impl<'a, 'b> MultiPolygonTrait for &'b MultiPolygon<'a> {
     type T = f64;
-    type PolygonType<'b>
-        = Polygon<'a>
+    type PolygonType<'c>
+        = &'b Polygon<'a>
     where
-        Self: 'b;
+        Self: 'c;
 
     fn dim(&self) -> Dimensions {
         self.dim.into()
@@ -111,6 +111,6 @@ impl<'a> MultiPolygonTrait for &MultiPolygon<'a> {
     }
 
     unsafe fn polygon_unchecked(&self, i: usize) -> Self::PolygonType<'_> {
-        self.wkb_polygons.get_unchecked(i).clone()
+        self.wkb_polygons.get_unchecked(i)
     }
 }

--- a/src/reader/polygon.rs
+++ b/src/reader/polygon.rs
@@ -77,7 +77,7 @@ impl<'a> Polygon<'a> {
 impl<'a> PolygonTrait for Polygon<'a> {
     type T = f64;
     type RingType<'b>
-        = WKBLinearRing<'a>
+        = &'b WKBLinearRing<'a>
     where
         Self: 'b;
 
@@ -98,21 +98,21 @@ impl<'a> PolygonTrait for Polygon<'a> {
         if self.wkb_linear_rings.is_empty() {
             None
         } else {
-            Some(self.wkb_linear_rings[0])
+            Some(&self.wkb_linear_rings[0])
         }
     }
 
     unsafe fn interior_unchecked(&self, i: usize) -> Self::RingType<'_> {
-        *self.wkb_linear_rings.get_unchecked(i + 1)
+        self.wkb_linear_rings.get_unchecked(i + 1)
     }
 }
 
-impl<'a> PolygonTrait for &Polygon<'a> {
+impl<'a, 'b> PolygonTrait for &'b Polygon<'a> {
     type T = f64;
-    type RingType<'b>
-        = WKBLinearRing<'a>
+    type RingType<'c>
+        = &'b WKBLinearRing<'a>
     where
-        Self: 'b;
+        Self: 'c;
 
     fn dim(&self) -> Dimensions {
         self.dim.into()
@@ -131,11 +131,11 @@ impl<'a> PolygonTrait for &Polygon<'a> {
         if self.wkb_linear_rings.is_empty() {
             None
         } else {
-            Some(self.wkb_linear_rings[0])
+            Some(&self.wkb_linear_rings[0])
         }
     }
 
     unsafe fn interior_unchecked(&self, i: usize) -> Self::RingType<'_> {
-        *self.wkb_linear_rings.get_unchecked(i + 1)
+        self.wkb_linear_rings.get_unchecked(i + 1)
     }
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
- [x] I ran cargo fmt
---

The generic associated types of Polygon, MultiLineString and MultiPolygon are defined as owned types, and we return a copy of the internal rings, line strings or polygons when their internal structures were accessed. This is not necessary because we can directly return an immutable reference for these accessor functions.

This patch changes some of the associated types to reference types to avoid creating copies when accessing the inner components of certain types of WKB geometries.