### PR TITLE
Fix the lifetime annotation of specialized implementation of GeometryTrait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Your change here.
 - Expose `wkb::reader::Wkb` type through public API.
 - Make lifetime annotations of `Wkb` more permissive. (#59)
+- Make lifetime annotations of specialized `GeometryTrait` implementations more permissive. (#63)
 
 ## 0.8.0 - 2024-12-03
 

--- a/src/reader/geometry.rs
+++ b/src/reader/geometry.rs
@@ -260,34 +260,34 @@ impl<'a> GeometryTrait for &Wkb<'a> {
 
 macro_rules! impl_specialization {
     ($geometry_type:ident) => {
-        impl GeometryTrait for $geometry_type<'_> {
+        impl<'a> GeometryTrait for $geometry_type<'a> {
             type T = f64;
             type PointType<'b>
-                = Point<'b>
+                = Point<'a>
             where
                 Self: 'b;
             type LineStringType<'b>
-                = LineString<'b>
+                = LineString<'a>
             where
                 Self: 'b;
             type PolygonType<'b>
-                = Polygon<'b>
+                = Polygon<'a>
             where
                 Self: 'b;
             type MultiPointType<'b>
-                = MultiPoint<'b>
+                = MultiPoint<'a>
             where
                 Self: 'b;
             type MultiLineStringType<'b>
-                = MultiLineString<'b>
+                = MultiLineString<'a>
             where
                 Self: 'b;
             type MultiPolygonType<'b>
-                = MultiPolygon<'b>
+                = MultiPolygon<'a>
             where
                 Self: 'b;
             type GeometryCollectionType<'b>
-                = GeometryCollection<'b>
+                = GeometryCollection<'a>
             where
                 Self: 'b;
             type RectType<'b>
@@ -311,13 +311,13 @@ macro_rules! impl_specialization {
                 &self,
             ) -> geo_traits::GeometryType<
                 '_,
-                Point,
-                LineString,
-                Polygon,
-                MultiPoint,
-                MultiLineString,
-                MultiPolygon,
-                GeometryCollection,
+                Point<'a>,
+                LineString<'a>,
+                Polygon<'a>,
+                MultiPoint<'a>,
+                MultiLineString<'a>,
+                MultiPolygon<'a>,
+                GeometryCollection<'a>,
                 Self::RectType<'_>,
                 Self::TriangleType<'_>,
                 Self::LineType<'_>,
@@ -326,34 +326,34 @@ macro_rules! impl_specialization {
             }
         }
 
-        impl<'a> GeometryTrait for &'a $geometry_type<'_> {
+        impl<'a> GeometryTrait for &$geometry_type<'a> {
             type T = f64;
             type PointType<'b>
-                = Point<'b>
+                = Point<'a>
             where
                 Self: 'b;
             type LineStringType<'b>
-                = LineString<'b>
+                = LineString<'a>
             where
                 Self: 'b;
             type PolygonType<'b>
-                = Polygon<'b>
+                = Polygon<'a>
             where
                 Self: 'b;
             type MultiPointType<'b>
-                = MultiPoint<'b>
+                = MultiPoint<'a>
             where
                 Self: 'b;
             type MultiLineStringType<'b>
-                = MultiLineString<'b>
+                = MultiLineString<'a>
             where
                 Self: 'b;
             type MultiPolygonType<'b>
-                = MultiPolygon<'b>
+                = MultiPolygon<'a>
             where
                 Self: 'b;
             type GeometryCollectionType<'b>
-                = GeometryCollection<'b>
+                = GeometryCollection<'a>
             where
                 Self: 'b;
             type RectType<'b>
@@ -377,13 +377,13 @@ macro_rules! impl_specialization {
                 &self,
             ) -> geo_traits::GeometryType<
                 '_,
-                Point,
-                LineString,
-                Polygon,
-                MultiPoint,
-                MultiLineString,
-                MultiPolygon,
-                GeometryCollection,
+                Point<'a>,
+                LineString<'a>,
+                Polygon<'a>,
+                MultiPoint<'a>,
+                MultiLineString<'a>,
+                MultiPolygon<'a>,
+                GeometryCollection<'a>,
                 Self::RectType<'_>,
                 Self::TriangleType<'_>,
                 Self::LineType<'_>,

--- a/src/test/wkb.rs
+++ b/src/test/wkb.rs
@@ -187,17 +187,15 @@ fn wkb_geo_traits_specialized_lifetime() {
     ];
     let coord = {
         let wkb = read_wkb(&buf).unwrap();
-        match wkb.as_type() {
-            geo_traits::GeometryType::Point(point) => match point.as_type() {
-                geo_traits::GeometryType::Point(point) => point.coord(),
-                _ => {
-                    panic!("Expected Point");
-                }
-            },
-            _ => {
-                panic!("Expected Point");
-            }
-        }
+        let geo_traits::GeometryType::Point(point) = wkb.as_type() else {
+            panic!("Expected Point");
+        };
+
+        let geo_traits::GeometryType::Point(point) = point.as_type() else {
+            panic!("Expected Point");
+        };
+
+        point.coord()
     };
 
     assert!(coord.is_some());

--- a/src/test/wkb.rs
+++ b/src/test/wkb.rs
@@ -1,5 +1,5 @@
 use geo_traits::to_geo::ToGeoGeometry;
-use geo_traits::{CoordTrait, GeometryTrait, LineStringTrait};
+use geo_traits::{CoordTrait, GeometryTrait, LineStringTrait, PointTrait};
 use geo_types::Geometry;
 
 use crate::reader::read_wkb;
@@ -168,6 +168,34 @@ fn wkb_geo_traits_lifetime() {
             }
             _ => {
                 panic!("Expected LineString");
+            }
+        }
+    };
+
+    assert!(coord.is_some());
+    assert_eq!(coord.unwrap().x(), 1.0);
+    assert_eq!(coord.unwrap().y(), 2.0);
+}
+
+#[test]
+fn wkb_geo_traits_specialized_lifetime() {
+    let buf = vec![
+        0x01, // little endian
+        0x01, 0x00, 0x00, 0x00, // type: Point (1)
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0x3F, // x: 1.0
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, // y: 2.0
+    ];
+    let coord = {
+        let wkb = read_wkb(&buf).unwrap();
+        match wkb.as_type() {
+            geo_traits::GeometryType::Point(point) => match point.as_type() {
+                geo_traits::GeometryType::Point(point) => point.coord(),
+                _ => {
+                    panic!("Expected Point");
+                }
+            },
+            _ => {
+                panic!("Expected Point");
             }
         }
     };


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
- [x] I ran cargo fmt
---

Just found another overly restrictive lifetime annotation in the specialized implementation of GeometryTrait for geometry types other than `Wkb`. The newly added test case fails without this patch:

```
error[E0597]: `wkb` does not live long enough
   --> src/test/wkb.rs:190:15
    |
188 |     let coord = {
    |         ----- borrow later stored here
189 |         let wkb = read_wkb(&buf).unwrap();
    |             --- binding `wkb` declared here
190 |         match wkb.as_type() {
    |               ^^^ borrowed value does not live long enough
...
205 |     };
    |     - `wkb` dropped here while still borrowed

For more information about this error, try `rustc --explain E0597`.
```