### PR TITLE
Standardize capitalization of `WKB` as `Wkb`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## Unreleased
 
 - Your change here.
+
+## 0.9.0 - unreleased
+
+- **BREAKING**: Standardize capitalization of `Wkb` in the codebase.
+  - `WKBResult` is now `WkbResult`.
+  - `WKBError` is now `WkbError`.
 - Expose `wkb::reader::Wkb` type through public API.
 - Make lifetime annotations of `Wkb` more permissive. (#59)
 - Define associated types as references for geo-traits implementations of MultiLineString, Polygon and MultiPolygon to avoid creating unnecessary copies. (#61)

--- a/src/common.rs
+++ b/src/common.rs
@@ -3,7 +3,7 @@ use std::io::Cursor;
 use byteorder::{BigEndian, LittleEndian, ReadBytesExt};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 
-use crate::error::{WKBError, WKBResult};
+use crate::error::{WkbError, WkbResult};
 
 /// Bit flag for EWKB Geometry with a z coordinate
 const EWKB_FLAG_Z: u32 = 0x80000000;
@@ -14,14 +14,14 @@ const EWKB_FLAG_SRID: u32 = 0x20000000;
 
 /// Supported WKB dimensions
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub enum WKBDimension {
+pub enum WkbDimension {
     Xy,
     Xyz,
     Xym,
     Xyzm,
 }
 
-impl WKBDimension {
+impl WkbDimension {
     fn as_u32_offset(&self) -> u32 {
         match self {
             Self::Xy => 0,
@@ -40,8 +40,8 @@ impl WKBDimension {
     }
 }
 
-impl TryFrom<geo_traits::Dimensions> for WKBDimension {
-    type Error = WKBError;
+impl TryFrom<geo_traits::Dimensions> for WkbDimension {
+    type Error = WkbError;
 
     fn try_from(value: geo_traits::Dimensions) -> Result<Self, Self::Error> {
         use geo_traits::Dimensions::*;
@@ -52,7 +52,7 @@ impl TryFrom<geo_traits::Dimensions> for WKBDimension {
             Xym => Self::Xym,
             Xyzm | Unknown(4) => Self::Xyzm,
             Unknown(n_dim) => {
-                return Err(WKBError::General(format!(
+                return Err(WkbError::General(format!(
                     "Unsupported number of dimensions: {}",
                     n_dim
                 )))
@@ -62,13 +62,13 @@ impl TryFrom<geo_traits::Dimensions> for WKBDimension {
     }
 }
 
-impl From<WKBDimension> for geo_traits::Dimensions {
-    fn from(value: WKBDimension) -> Self {
+impl From<WkbDimension> for geo_traits::Dimensions {
+    fn from(value: WkbDimension) -> Self {
         match value {
-            WKBDimension::Xy => Self::Xy,
-            WKBDimension::Xyz => Self::Xyz,
-            WKBDimension::Xym => Self::Xym,
-            WKBDimension::Xyzm => Self::Xyzm,
+            WkbDimension::Xy => Self::Xy,
+            WkbDimension::Xyz => Self::Xyz,
+            WkbDimension::Xym => Self::Xym,
+            WkbDimension::Xyzm => Self::Xyzm,
         }
     }
 }
@@ -81,9 +81,9 @@ impl From<WKBDimension> for geo_traits::Dimensions {
 /// In extended WKB this additionally informs whether there's a u32 SRID immediately after this,
 /// which we need to know to skip.
 #[repr(transparent)]
-pub(crate) struct WKBGeometryCode(u32);
+pub(crate) struct WkbGeometryCode(u32);
 
-impl WKBGeometryCode {
+impl WkbGeometryCode {
     pub(crate) fn new(code: u32) -> Self {
         Self(code)
     }
@@ -92,9 +92,9 @@ impl WKBGeometryCode {
         self.0 & EWKB_FLAG_SRID == EWKB_FLAG_SRID
     }
 
-    pub(crate) fn get_type(&self) -> WKBResult<WKBType> {
+    pub(crate) fn get_type(&self) -> WkbResult<WkbType> {
         let code = self.0;
-        let mut dim = WKBDimension::Xy;
+        let mut dim = WkbDimension::Xy;
 
         // For ISO WKB:
         // Values 1, 2, 3 are 2D,
@@ -102,9 +102,9 @@ impl WKBGeometryCode {
         // 2001 etc are XYM,
         // 3001 etc are XYZM
         match code / 1000 {
-            1 => dim = WKBDimension::Xyz,
-            2 => dim = WKBDimension::Xym,
-            3 => dim = WKBDimension::Xyzm,
+            1 => dim = WkbDimension::Xyz,
+            2 => dim = WkbDimension::Xym,
+            3 => dim = WkbDimension::Xyzm,
             _ => (),
         };
 
@@ -113,22 +113,22 @@ impl WKBGeometryCode {
         let is_ewkb_m = code & EWKB_FLAG_M == EWKB_FLAG_M;
 
         match (is_ewkb_z, is_ewkb_m) {
-            (true, true) => dim = WKBDimension::Xyzm,
-            (true, false) => dim = WKBDimension::Xyz,
-            (false, true) => dim = WKBDimension::Xym,
+            (true, true) => dim = WkbDimension::Xyzm,
+            (true, false) => dim = WkbDimension::Xyz,
+            (false, true) => dim = WkbDimension::Xym,
             _ => (),
         }
 
         let typ = match code & 0x7 {
-            1 => WKBType::Point(dim),
-            2 => WKBType::LineString(dim),
-            3 => WKBType::Polygon(dim),
-            4 => WKBType::MultiPoint(dim),
-            5 => WKBType::MultiLineString(dim),
-            6 => WKBType::MultiPolygon(dim),
-            7 => WKBType::GeometryCollection(dim),
+            1 => WkbType::Point(dim),
+            2 => WkbType::LineString(dim),
+            3 => WkbType::Polygon(dim),
+            4 => WkbType::MultiPoint(dim),
+            5 => WkbType::MultiLineString(dim),
+            6 => WkbType::MultiPolygon(dim),
+            7 => WkbType::GeometryCollection(dim),
             _ => {
-                return Err(WKBError::General(format!(
+                return Err(WkbError::General(format!(
                     "WKB type code out of range. Got: {}",
                     code
                 )))
@@ -140,42 +140,42 @@ impl WKBGeometryCode {
 
 /// The various WKB types supported by this crate
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub enum WKBType {
+pub enum WkbType {
     /// A WKB Point
-    Point(WKBDimension),
+    Point(WkbDimension),
     /// A WKB LineString
-    LineString(WKBDimension),
+    LineString(WkbDimension),
     /// A WKB Polygon
-    Polygon(WKBDimension),
+    Polygon(WkbDimension),
     /// A WKB MultiPoint
-    MultiPoint(WKBDimension),
+    MultiPoint(WkbDimension),
     /// A WKB MultiLineString
-    MultiLineString(WKBDimension),
+    MultiLineString(WkbDimension),
     /// A WKB MultiPolygon
-    MultiPolygon(WKBDimension),
+    MultiPolygon(WkbDimension),
     /// A WKB GeometryCollection
-    GeometryCollection(WKBDimension),
+    GeometryCollection(WkbDimension),
 }
 
-impl WKBType {
+impl WkbType {
     /// Construct from a byte slice representing a WKB geometry
-    pub(crate) fn from_buffer(buf: &[u8]) -> WKBResult<Self> {
+    pub(crate) fn from_buffer(buf: &[u8]) -> WkbResult<Self> {
         let mut reader = Cursor::new(buf);
         let byte_order = reader.read_u8().unwrap();
         let geometry_code = match byte_order {
             0 => reader.read_u32::<BigEndian>().unwrap(),
             1 => reader.read_u32::<LittleEndian>().unwrap(),
             other => {
-                return Err(WKBError::General(format!(
+                return Err(WkbError::General(format!(
                     "Unexpected byte order: {}",
                     other
                 )))
             }
         };
-        WKBGeometryCode(geometry_code).get_type()
+        WkbGeometryCode(geometry_code).get_type()
     }
 
-    pub(crate) fn as_geometry_code(&self) -> WKBGeometryCode {
+    pub(crate) fn as_geometry_code(&self) -> WkbGeometryCode {
         let code = match self {
             Self::Point(dim) => 1 + dim.as_u32_offset(),
             Self::LineString(dim) => 2 + dim.as_u32_offset(),
@@ -185,12 +185,12 @@ impl WKBType {
             Self::MultiPolygon(dim) => 6 + dim.as_u32_offset(),
             Self::GeometryCollection(dim) => 7 + dim.as_u32_offset(),
         };
-        WKBGeometryCode(code)
+        WkbGeometryCode(code)
     }
 }
 
-impl From<WKBType> for u32 {
-    fn from(value: WKBType) -> Self {
+impl From<WkbType> for u32 {
+    fn from(value: WkbType) -> Self {
         value.as_geometry_code().0
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-//! Defines [`WKBError`], representing all errors returned by this crate.
+//! Defines [`WkbError`], representing all errors returned by this crate.
 
 use std::borrow::Cow;
 use std::fmt::Debug;
@@ -7,7 +7,7 @@ use thiserror::Error;
 /// Enum with all errors in this crate.
 #[derive(Error, Debug)]
 #[non_exhaustive]
-pub enum WKBError {
+pub enum WkbError {
     /// Incorrect type was passed to an operation.
     #[error("Incorrect type passed to operation: {0}")]
     IncorrectType(Cow<'static, str>),
@@ -26,4 +26,4 @@ pub enum WKBError {
 }
 
 /// Crate-specific result type.
-pub type WKBResult<T> = std::result::Result<T, WKBError>;
+pub type WkbResult<T> = std::result::Result<T, WkbError>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,4 +7,4 @@ pub mod reader;
 mod test;
 pub mod writer;
 
-pub use common::{Endianness, WKBType};
+pub use common::{Endianness, WkbType};

--- a/src/reader/coord.rs
+++ b/src/reader/coord.rs
@@ -1,6 +1,6 @@
 use std::io::Cursor;
 
-use crate::common::WKBDimension;
+use crate::common::WkbDimension;
 use crate::reader::util::ReadBytesExt;
 use crate::Endianness;
 use geo_traits::{CoordTrait, Dimensions};
@@ -31,7 +31,7 @@ pub struct Coord<'a> {
     /// `Point` objects.
     offset: u64,
 
-    dim: WKBDimension,
+    dim: WkbDimension,
 }
 
 impl<'a> Coord<'a> {
@@ -39,7 +39,7 @@ impl<'a> Coord<'a> {
         buf: &'a [u8],
         byte_order: Endianness,
         offset: u64,
-        dim: WKBDimension,
+        dim: WkbDimension,
     ) -> Self {
         Self {
             buf,

--- a/src/reader/geometry_collection.rs
+++ b/src/reader/geometry_collection.rs
@@ -1,7 +1,7 @@
 use std::io::Cursor;
 
-use crate::common::WKBDimension;
-use crate::error::WKBResult;
+use crate::common::WkbDimension;
+use crate::error::WkbResult;
 use crate::reader::util::{has_srid, ReadBytesExt};
 use crate::reader::Wkb;
 use crate::Endianness;
@@ -15,12 +15,12 @@ const HEADER_BYTES: u64 = 5;
 pub struct GeometryCollection<'a> {
     /// A WKB object for each of the internal geometries
     geometries: Vec<Wkb<'a>>,
-    dim: WKBDimension,
+    dim: WkbDimension,
     has_srid: bool,
 }
 
 impl<'a> GeometryCollection<'a> {
-    pub fn try_new(buf: &'a [u8], byte_order: Endianness, dim: WKBDimension) -> WKBResult<Self> {
+    pub fn try_new(buf: &'a [u8], byte_order: Endianness, dim: WkbDimension) -> WkbResult<Self> {
         let mut offset = 0;
         let has_srid = has_srid(buf, byte_order, offset);
         if has_srid {
@@ -53,7 +53,7 @@ impl<'a> GeometryCollection<'a> {
         })
     }
 
-    pub fn dimension(&self) -> WKBDimension {
+    pub fn dimension(&self) -> WkbDimension {
         self.dim
     }
 

--- a/src/reader/linearring.rs
+++ b/src/reader/linearring.rs
@@ -1,6 +1,6 @@
 use std::io::Cursor;
 
-use crate::common::WKBDimension;
+use crate::common::WkbDimension;
 use crate::reader::coord::Coord;
 use crate::reader::util::ReadBytesExt;
 use crate::Endianness;
@@ -13,7 +13,7 @@ use geo_traits::LineStringTrait;
 ///
 /// See page 65 of <https://portal.ogc.org/files/?artifact_id=25355>.
 #[derive(Debug, Clone, Copy)]
-pub struct WKBLinearRing<'a> {
+pub struct LinearRing<'a> {
     /// The underlying WKB buffer
     buf: &'a [u8],
 
@@ -31,11 +31,11 @@ pub struct WKBLinearRing<'a> {
     /// The number of points in this linear ring
     num_points: usize,
 
-    dim: WKBDimension,
+    dim: WkbDimension,
 }
 
-impl<'a> WKBLinearRing<'a> {
-    pub fn new(buf: &'a [u8], byte_order: Endianness, offset: u64, dim: WKBDimension) -> Self {
+impl<'a> LinearRing<'a> {
+    pub fn new(buf: &'a [u8], byte_order: Endianness, offset: u64, dim: WkbDimension) -> Self {
         let mut reader = Cursor::new(buf);
         reader.set_position(offset);
         let num_points = reader.read_u32(byte_order).unwrap().try_into().unwrap();
@@ -65,7 +65,7 @@ impl<'a> WKBLinearRing<'a> {
     }
 }
 
-impl<'a> LineStringTrait for WKBLinearRing<'a> {
+impl<'a> LineStringTrait for LinearRing<'a> {
     type T = f64;
     type CoordType<'b>
         = Coord<'a>
@@ -92,7 +92,7 @@ impl<'a> LineStringTrait for WKBLinearRing<'a> {
     }
 }
 
-impl<'a> LineStringTrait for &WKBLinearRing<'a> {
+impl<'a> LineStringTrait for &LinearRing<'a> {
     type T = f64;
     type CoordType<'c>
         = Coord<'a>

--- a/src/reader/linestring.rs
+++ b/src/reader/linestring.rs
@@ -1,6 +1,6 @@
 use std::io::Cursor;
 
-use crate::common::WKBDimension;
+use crate::common::WkbDimension;
 use crate::reader::coord::Coord;
 use crate::reader::util::{has_srid, ReadBytesExt};
 use crate::Endianness;
@@ -23,12 +23,12 @@ pub struct LineString<'a> {
     /// This offset will be 0 for a single LineString but it will be non zero for a
     /// LineString contained within a MultiLineString
     offset: u64,
-    dim: WKBDimension,
+    dim: WkbDimension,
     has_srid: bool,
 }
 
 impl<'a> LineString<'a> {
-    pub fn new(buf: &'a [u8], byte_order: Endianness, mut offset: u64, dim: WKBDimension) -> Self {
+    pub fn new(buf: &'a [u8], byte_order: Endianness, mut offset: u64, dim: WkbDimension) -> Self {
         let has_srid = has_srid(buf, byte_order, offset);
         if has_srid {
             offset += 4;
@@ -68,7 +68,7 @@ impl<'a> LineString<'a> {
         self.offset + 1 + 4 + 4 + (self.dim.size() as u64 * 8 * i)
     }
 
-    pub fn dimension(&self) -> WKBDimension {
+    pub fn dimension(&self) -> WkbDimension {
         self.dim
     }
 }

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -24,11 +24,11 @@ use multipolygon::MultiPolygon;
 use point::Point;
 use polygon::Polygon;
 
-use crate::error::WKBResult;
+use crate::error::WkbResult;
 
 /// Parse a WKB byte slice into a geometry.
 ///
 /// This is an alias for [`Wkb::try_new`].
-pub fn read_wkb(buf: &[u8]) -> WKBResult<Wkb> {
+pub fn read_wkb(buf: &[u8]) -> WkbResult<Wkb> {
     Wkb::try_new(buf)
 }

--- a/src/reader/multilinestring.rs
+++ b/src/reader/multilinestring.rs
@@ -1,6 +1,6 @@
 use std::io::Cursor;
 
-use crate::common::WKBDimension;
+use crate::common::WkbDimension;
 use crate::reader::linestring::LineString;
 use crate::reader::util::{has_srid, ReadBytesExt};
 use crate::Endianness;
@@ -16,12 +16,12 @@ const HEADER_BYTES: u64 = 5;
 pub struct MultiLineString<'a> {
     /// A LineString object for each of the internal line strings
     wkb_line_strings: Vec<LineString<'a>>,
-    dim: WKBDimension,
+    dim: WkbDimension,
     has_srid: bool,
 }
 
 impl<'a> MultiLineString<'a> {
-    pub(crate) fn new(buf: &'a [u8], byte_order: Endianness, dim: WKBDimension) -> Self {
+    pub(crate) fn new(buf: &'a [u8], byte_order: Endianness, dim: WkbDimension) -> Self {
         let mut offset = 0;
         let has_srid = has_srid(buf, byte_order, offset);
         if has_srid {
@@ -71,7 +71,7 @@ impl<'a> MultiLineString<'a> {
             .fold(header, |acc, ls| acc + ls.size())
     }
 
-    pub fn dimension(&self) -> WKBDimension {
+    pub fn dimension(&self) -> WkbDimension {
         self.dim
     }
 }

--- a/src/reader/multipoint.rs
+++ b/src/reader/multipoint.rs
@@ -1,6 +1,6 @@
 use std::io::Cursor;
 
-use crate::common::WKBDimension;
+use crate::common::WkbDimension;
 use crate::reader::point::Point;
 use crate::reader::util::{has_srid, ReadBytesExt};
 use crate::Endianness;
@@ -17,12 +17,12 @@ pub struct MultiPoint<'a> {
 
     /// The number of points in this multi point
     num_points: usize,
-    dim: WKBDimension,
+    dim: WkbDimension,
     has_srid: bool,
 }
 
 impl<'a> MultiPoint<'a> {
-    pub(crate) fn new(buf: &'a [u8], byte_order: Endianness, dim: WKBDimension) -> Self {
+    pub(crate) fn new(buf: &'a [u8], byte_order: Endianness, dim: WkbDimension) -> Self {
         let mut offset = 0;
         let has_srid = has_srid(buf, byte_order, offset);
         if has_srid {
@@ -70,7 +70,7 @@ impl<'a> MultiPoint<'a> {
         header + ((1 + 4 + (self.dim.size() as u64 * 8)) * i)
     }
 
-    pub fn dimension(&self) -> WKBDimension {
+    pub fn dimension(&self) -> WkbDimension {
         self.dim
     }
 }

--- a/src/reader/multipolygon.rs
+++ b/src/reader/multipolygon.rs
@@ -1,6 +1,6 @@
 use std::io::Cursor;
 
-use crate::common::WKBDimension;
+use crate::common::WkbDimension;
 use crate::reader::polygon::Polygon;
 use crate::reader::util::{has_srid, ReadBytesExt};
 use crate::Endianness;
@@ -16,12 +16,12 @@ pub struct MultiPolygon<'a> {
     /// A Polygon object for each of the internal line strings
     wkb_polygons: Vec<Polygon<'a>>,
 
-    dim: WKBDimension,
+    dim: WkbDimension,
     has_srid: bool,
 }
 
 impl<'a> MultiPolygon<'a> {
-    pub(crate) fn new(buf: &'a [u8], byte_order: Endianness, dim: WKBDimension) -> Self {
+    pub(crate) fn new(buf: &'a [u8], byte_order: Endianness, dim: WkbDimension) -> Self {
         let mut offset = 0;
         let has_srid = has_srid(buf, byte_order, offset);
         if has_srid {
@@ -70,7 +70,7 @@ impl<'a> MultiPolygon<'a> {
             .fold(header, |acc, x| acc + x.size())
     }
 
-    pub fn dimension(&self) -> WKBDimension {
+    pub fn dimension(&self) -> WkbDimension {
         self.dim
     }
 }

--- a/src/reader/point.rs
+++ b/src/reader/point.rs
@@ -1,4 +1,4 @@
-use crate::common::WKBDimension;
+use crate::common::WkbDimension;
 use crate::reader::coord::Coord;
 use crate::reader::util::has_srid;
 use crate::Endianness;
@@ -14,7 +14,7 @@ use geo_traits::{CoordTrait, PointTrait};
 pub struct Point<'a> {
     /// The coordinate inside this Point
     coord: Coord<'a>,
-    dim: WKBDimension,
+    dim: WkbDimension,
     is_empty: bool,
     has_srid: bool,
 }
@@ -24,7 +24,7 @@ impl<'a> Point<'a> {
         buf: &'a [u8],
         byte_order: Endianness,
         offset: u64,
-        dim: WKBDimension,
+        dim: WkbDimension,
     ) -> Self {
         let has_srid = has_srid(buf, byte_order, offset);
 
@@ -67,7 +67,7 @@ impl<'a> Point<'a> {
         header + (self.dim.size() as u64 * 8)
     }
 
-    pub fn dimension(&self) -> WKBDimension {
+    pub fn dimension(&self) -> WkbDimension {
         self.dim
     }
 }

--- a/src/reader/polygon.rs
+++ b/src/reader/polygon.rs
@@ -1,7 +1,7 @@
 use std::io::Cursor;
 
-use crate::common::WKBDimension;
-use crate::reader::linearring::WKBLinearRing;
+use crate::common::WkbDimension;
+use crate::reader::linearring::LinearRing;
 use crate::reader::util::{has_srid, ReadBytesExt};
 use crate::Endianness;
 use geo_traits::Dimensions;
@@ -15,13 +15,13 @@ const HEADER_BYTES: u64 = 5;
 /// This has been preprocessed, so access to any internal coordinate is `O(1)`.
 #[derive(Debug, Clone)]
 pub struct Polygon<'a> {
-    wkb_linear_rings: Vec<WKBLinearRing<'a>>,
-    dim: WKBDimension,
+    wkb_linear_rings: Vec<LinearRing<'a>>,
+    dim: WkbDimension,
     has_srid: bool,
 }
 
 impl<'a> Polygon<'a> {
-    pub fn new(buf: &'a [u8], byte_order: Endianness, mut offset: u64, dim: WKBDimension) -> Self {
+    pub fn new(buf: &'a [u8], byte_order: Endianness, mut offset: u64, dim: WkbDimension) -> Self {
         let has_srid = has_srid(buf, byte_order, offset);
         if has_srid {
             offset += 4;
@@ -39,7 +39,7 @@ impl<'a> Polygon<'a> {
         let mut ring_offset = offset + 1 + 4 + 4;
         let mut wkb_linear_rings = Vec::with_capacity(num_rings);
         for _ in 0..num_rings {
-            let polygon = WKBLinearRing::new(buf, byte_order, ring_offset, dim);
+            let polygon = LinearRing::new(buf, byte_order, ring_offset, dim);
             wkb_linear_rings.push(polygon);
             ring_offset += polygon.size();
         }
@@ -69,7 +69,7 @@ impl<'a> Polygon<'a> {
             .fold(header, |acc, ring| acc + ring.size())
     }
 
-    pub fn dimension(&self) -> WKBDimension {
+    pub fn dimension(&self) -> WkbDimension {
         self.dim
     }
 }
@@ -77,7 +77,7 @@ impl<'a> Polygon<'a> {
 impl<'a> PolygonTrait for Polygon<'a> {
     type T = f64;
     type RingType<'b>
-        = &'b WKBLinearRing<'a>
+        = &'b LinearRing<'a>
     where
         Self: 'b;
 
@@ -110,7 +110,7 @@ impl<'a> PolygonTrait for Polygon<'a> {
 impl<'a, 'b> PolygonTrait for &'b Polygon<'a> {
     type T = f64;
     type RingType<'c>
-        = &'b WKBLinearRing<'a>
+        = &'b LinearRing<'a>
     where
         Self: 'c;
 

--- a/src/reader/util.rs
+++ b/src/reader/util.rs
@@ -1,6 +1,6 @@
 use byteorder::{BigEndian, LittleEndian};
 
-use crate::common::WKBGeometryCode;
+use crate::common::WkbGeometryCode;
 use crate::Endianness;
 use std::io::{Cursor, Error};
 
@@ -32,6 +32,6 @@ pub(crate) fn has_srid(buf: &[u8], byte_order: Endianness, offset: u64) -> bool 
     // Skip 1-byte byte order that we already know
     reader.set_position(1 + offset);
 
-    let geometry_code = WKBGeometryCode::new(reader.read_u32(byte_order).unwrap());
+    let geometry_code = WkbGeometryCode::new(reader.read_u32(byte_order).unwrap());
     geometry_code.has_srid()
 }

--- a/src/writer/coord.rs
+++ b/src/writer/coord.rs
@@ -3,13 +3,13 @@ use std::io::Write;
 use byteorder::{ByteOrder, WriteBytesExt};
 use geo_traits::CoordTrait;
 
-use crate::error::WKBResult;
+use crate::error::WkbResult;
 
 /// Write a coordinate to a Writer encoded as WKB
 pub(crate) fn write_coord<B: ByteOrder>(
     writer: &mut impl Write,
     coord: &impl CoordTrait<T = f64>,
-) -> WKBResult<()> {
+) -> WkbResult<()> {
     for i in 0..coord.dim().size() {
         // # Safety
         // We just checked the number of dimensions in this coord

--- a/src/writer/geometry.rs
+++ b/src/writer/geometry.rs
@@ -1,4 +1,4 @@
-use crate::error::WKBResult;
+use crate::error::WkbResult;
 use crate::writer::{
     geometry_collection_wkb_size, line_string_wkb_size, line_wkb_size, multi_line_string_wkb_size,
     multi_point_wkb_size, multi_polygon_wkb_size, point_wkb_size, polygon_wkb_size, rect_wkb_size,
@@ -32,7 +32,7 @@ pub fn write_geometry(
     writer: &mut impl Write,
     geom: &impl GeometryTrait<T = f64>,
     endianness: Endianness,
-) -> WKBResult<()> {
+) -> WkbResult<()> {
     use GeometryType::*;
     match geom.as_type() {
         Point(p) => write_point(writer, p, endianness),

--- a/src/writer/geometrycollection.rs
+++ b/src/writer/geometrycollection.rs
@@ -1,5 +1,5 @@
-use crate::common::WKBType;
-use crate::error::WKBResult;
+use crate::common::WkbType;
+use crate::error::WkbResult;
 use crate::writer::geometry::{geometry_wkb_size, write_geometry};
 use crate::Endianness;
 use byteorder::{BigEndian, ByteOrder, LittleEndian, WriteBytesExt};
@@ -22,7 +22,7 @@ pub fn write_geometry_collection(
     writer: &mut impl Write,
     geom: &impl GeometryCollectionTrait<T = f64>,
     endianness: Endianness,
-) -> WKBResult<()> {
+) -> WkbResult<()> {
     // Byte order
     writer.write_u8(endianness.into())?;
 
@@ -41,8 +41,8 @@ fn write_geometry_collection_content<B: ByteOrder>(
     writer: &mut impl Write,
     geom: &impl GeometryCollectionTrait<T = f64>,
     endianness: Endianness,
-) -> WKBResult<()> {
-    let wkb_type = WKBType::GeometryCollection(geom.dim().try_into()?);
+) -> WkbResult<()> {
+    let wkb_type = WkbType::GeometryCollection(geom.dim().try_into()?);
     writer.write_u32::<B>(wkb_type.into())?;
 
     // numGeometries

--- a/src/writer/line.rs
+++ b/src/writer/line.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 use geo_traits::{LineStringTrait, LineTrait};
 
-use crate::error::WKBResult;
+use crate::error::WkbResult;
 use crate::writer::{line_string_wkb_size, write_line_string};
 use crate::Endianness;
 
@@ -44,6 +44,6 @@ pub fn write_line(
     writer: &mut impl Write,
     geom: &impl LineTrait<T = f64>,
     endianness: Endianness,
-) -> WKBResult<()> {
+) -> WkbResult<()> {
     write_line_string(writer, &LineWrapper(geom), endianness)
 }

--- a/src/writer/linestring.rs
+++ b/src/writer/linestring.rs
@@ -1,5 +1,5 @@
-use crate::common::WKBType;
-use crate::error::WKBResult;
+use crate::common::WkbType;
+use crate::error::WkbResult;
 use crate::writer::coord::write_coord;
 use crate::Endianness;
 use byteorder::{BigEndian, ByteOrder, LittleEndian, WriteBytesExt};
@@ -19,7 +19,7 @@ pub fn write_line_string(
     writer: &mut impl Write,
     geom: &impl LineStringTrait<T = f64>,
     endianness: Endianness,
-) -> WKBResult<()> {
+) -> WkbResult<()> {
     // Byte order
     writer.write_u8(endianness.into()).unwrap();
 
@@ -33,8 +33,8 @@ pub fn write_line_string(
 fn write_line_string_content<B: ByteOrder>(
     writer: &mut impl Write,
     geom: &impl LineStringTrait<T = f64>,
-) -> WKBResult<()> {
-    let wkb_type = WKBType::LineString(geom.dim().try_into()?);
+) -> WkbResult<()> {
+    let wkb_type = WkbType::LineString(geom.dim().try_into()?);
     writer.write_u32::<B>(wkb_type.into())?;
 
     // numPoints

--- a/src/writer/multilinestring.rs
+++ b/src/writer/multilinestring.rs
@@ -1,5 +1,5 @@
-use crate::common::WKBType;
-use crate::error::WKBResult;
+use crate::common::WkbType;
+use crate::error::WkbResult;
 use crate::writer::linestring::{line_string_wkb_size, write_line_string};
 use crate::Endianness;
 use byteorder::{BigEndian, ByteOrder, LittleEndian, WriteBytesExt};
@@ -21,7 +21,7 @@ pub fn write_multi_line_string(
     writer: &mut impl Write,
     geom: &impl MultiLineStringTrait<T = f64>,
     endianness: Endianness,
-) -> WKBResult<()> {
+) -> WkbResult<()> {
     // Byte order
     writer.write_u8(endianness.into())?;
 
@@ -40,8 +40,8 @@ fn write_multi_line_string_content<B: ByteOrder>(
     writer: &mut impl Write,
     geom: &impl MultiLineStringTrait<T = f64>,
     endianness: Endianness,
-) -> WKBResult<()> {
-    let wkb_type = WKBType::MultiLineString(geom.dim().try_into()?);
+) -> WkbResult<()> {
+    let wkb_type = WkbType::MultiLineString(geom.dim().try_into()?);
     writer.write_u32::<B>(wkb_type.into())?;
 
     // numPoints

--- a/src/writer/multipoint.rs
+++ b/src/writer/multipoint.rs
@@ -1,5 +1,5 @@
-use crate::common::WKBType;
-use crate::error::WKBResult;
+use crate::common::WkbType;
+use crate::error::WkbResult;
 use crate::writer::point::{point_wkb_size, write_point};
 use crate::Endianness;
 use byteorder::{BigEndian, ByteOrder, LittleEndian, WriteBytesExt};
@@ -16,7 +16,7 @@ pub fn write_multi_point(
     writer: &mut impl Write,
     geom: &impl MultiPointTrait<T = f64>,
     endianness: Endianness,
-) -> WKBResult<()> {
+) -> WkbResult<()> {
     // Byte order
     writer.write_u8(endianness.into())?;
 
@@ -33,8 +33,8 @@ fn write_multi_point_content<B: ByteOrder>(
     writer: &mut impl Write,
     geom: &impl MultiPointTrait<T = f64>,
     endianness: Endianness,
-) -> WKBResult<()> {
-    let wkb_type = WKBType::MultiPoint(geom.dim().try_into()?);
+) -> WkbResult<()> {
+    let wkb_type = WkbType::MultiPoint(geom.dim().try_into()?);
     writer.write_u32::<B>(wkb_type.into())?;
 
     // numPoints

--- a/src/writer/multipolygon.rs
+++ b/src/writer/multipolygon.rs
@@ -1,5 +1,5 @@
-use crate::common::WKBType;
-use crate::error::WKBResult;
+use crate::common::WkbType;
+use crate::error::WkbResult;
 use crate::writer::polygon::{polygon_wkb_size, write_polygon};
 use crate::Endianness;
 use byteorder::{BigEndian, ByteOrder, LittleEndian, WriteBytesExt};
@@ -21,7 +21,7 @@ pub fn write_multi_polygon(
     writer: &mut impl Write,
     geom: &impl MultiPolygonTrait<T = f64>,
     endianness: Endianness,
-) -> WKBResult<()> {
+) -> WkbResult<()> {
     // Byte order
     writer.write_u8(endianness.into())?;
 
@@ -38,8 +38,8 @@ fn write_multi_polygon_content<B: ByteOrder>(
     writer: &mut impl Write,
     geom: &impl MultiPolygonTrait<T = f64>,
     endianness: Endianness,
-) -> WKBResult<()> {
-    let wkb_type = WKBType::MultiPolygon(geom.dim().try_into()?);
+) -> WkbResult<()> {
+    let wkb_type = WkbType::MultiPolygon(geom.dim().try_into()?);
     writer.write_u32::<B>(wkb_type.into())?;
 
     // numPolygons

--- a/src/writer/point.rs
+++ b/src/writer/point.rs
@@ -1,5 +1,5 @@
-use crate::common::WKBType;
-use crate::error::WKBResult;
+use crate::common::WkbType;
+use crate::error::WkbResult;
 use crate::writer::coord::write_coord;
 use crate::Endianness;
 use byteorder::{BigEndian, ByteOrder, LittleEndian, WriteBytesExt};
@@ -19,7 +19,7 @@ pub fn write_point(
     writer: &mut impl Write,
     geom: &impl PointTrait<T = f64>,
     endianness: Endianness,
-) -> WKBResult<()> {
+) -> WkbResult<()> {
     // Byte order header
     writer.write_u8(endianness.into())?;
 
@@ -34,8 +34,8 @@ pub fn write_point(
 fn write_point_content<B: ByteOrder>(
     writer: &mut impl Write,
     geom: &impl PointTrait<T = f64>,
-) -> WKBResult<()> {
-    let wkb_type = WKBType::Point(geom.dim().try_into()?);
+) -> WkbResult<()> {
+    let wkb_type = WkbType::Point(geom.dim().try_into()?);
     writer.write_u32::<B>(wkb_type.into())?;
 
     if let Some(coord) = geom.coord() {

--- a/src/writer/polygon.rs
+++ b/src/writer/polygon.rs
@@ -1,5 +1,5 @@
-use crate::common::WKBType;
-use crate::error::WKBResult;
+use crate::common::WkbType;
+use crate::error::WkbResult;
 use crate::writer::coord::write_coord;
 use crate::Endianness;
 use byteorder::{BigEndian, ByteOrder, LittleEndian, WriteBytesExt};
@@ -28,7 +28,7 @@ pub fn write_polygon(
     writer: &mut impl Write,
     geom: &impl PolygonTrait<T = f64>,
     endianness: Endianness,
-) -> WKBResult<()> {
+) -> WkbResult<()> {
     // Byte order
     writer.write_u8(endianness.into())?;
 
@@ -42,8 +42,8 @@ pub fn write_polygon(
 fn write_polygon_content<B: ByteOrder>(
     writer: &mut impl Write,
     geom: &impl PolygonTrait<T = f64>,
-) -> WKBResult<()> {
-    let wkb_type = WKBType::Polygon(geom.dim().try_into()?);
+) -> WkbResult<()> {
+    let wkb_type = WkbType::Polygon(geom.dim().try_into()?);
     writer.write_u32::<B>(wkb_type.into())?;
 
     // numRings

--- a/src/writer/rect.rs
+++ b/src/writer/rect.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 use geo_traits::{CoordTrait, LineStringTrait, PolygonTrait, RectTrait};
 
-use crate::error::WKBResult;
+use crate::error::WkbResult;
 use crate::writer::{polygon_wkb_size, write_polygon};
 use crate::Endianness;
 
@@ -119,6 +119,6 @@ pub fn write_rect(
     writer: &mut impl Write,
     geom: &impl RectTrait<T = f64>,
     endianness: Endianness,
-) -> WKBResult<()> {
+) -> WkbResult<()> {
     write_polygon(writer, &RectWrapper(geom), endianness)
 }

--- a/src/writer/triangle.rs
+++ b/src/writer/triangle.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 use geo_traits::{LineStringTrait, PolygonTrait, TriangleTrait};
 
-use crate::error::WKBResult;
+use crate::error::WkbResult;
 use crate::writer::{polygon_wkb_size, write_polygon};
 use crate::Endianness;
 
@@ -70,6 +70,6 @@ pub fn write_triangle(
     writer: &mut impl Write,
     geom: &impl TriangleTrait<T = f64>,
     endianness: Endianness,
-) -> WKBResult<()> {
+) -> WkbResult<()> {
     write_polygon(writer, &TriangleWrapper(geom), endianness)
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
- [x] I ran cargo fmt
---

Closes https://github.com/georust/wkb/issues/56

We already had `Wkb` in the public API. I think it would be best if we standardized on `Wkb` as a consistent spelling.

- `WKBResult` is now `WkbResult`.
- `WKBError` is now `WkbError`.
- (not public) `WKBDimension` is now `WkbDimension`.
- (exported but impossible to use because WkbDimension is private 🙈 #48) `WKBType` is now `WkbType`.
- (not public) `WKBLinearRing` is now `LinearRing`
