### PR TITLE
Expose `GeometryType` and `Dimension` from parsed `Wkb` object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Your change here.
+- Expose `GeometryType` and `Dimension` from parsed `Wkb` object (#65).
 - Expose `wkb::reader::Wkb` type through public API.
 - Make lifetime annotations of `Wkb` more permissive. (#59)
 - Define associated types as references for geo-traits implementations of MultiLineString, Polygon and MultiPolygon to avoid creating unnecessary copies. (#61)

--- a/src/common.rs
+++ b/src/common.rs
@@ -41,7 +41,7 @@ impl Dimension {
 }
 
 impl TryFrom<geo_traits::Dimensions> for Dimension {
-    type Error = WKBError;
+    type Error = WkbError;
 
     fn try_from(value: geo_traits::Dimensions) -> Result<Self, Self::Error> {
         use geo_traits::Dimensions::*;

--- a/src/common.rs
+++ b/src/common.rs
@@ -14,14 +14,14 @@ const EWKB_FLAG_SRID: u32 = 0x20000000;
 
 /// Supported WKB dimensions
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub enum WKBDimension {
+pub enum Dimension {
     Xy,
     Xyz,
     Xym,
     Xyzm,
 }
 
-impl WKBDimension {
+impl Dimension {
     fn as_u32_offset(&self) -> u32 {
         match self {
             Self::Xy => 0,
@@ -40,7 +40,7 @@ impl WKBDimension {
     }
 }
 
-impl TryFrom<geo_traits::Dimensions> for WKBDimension {
+impl TryFrom<geo_traits::Dimensions> for Dimension {
     type Error = WKBError;
 
     fn try_from(value: geo_traits::Dimensions) -> Result<Self, Self::Error> {
@@ -62,13 +62,13 @@ impl TryFrom<geo_traits::Dimensions> for WKBDimension {
     }
 }
 
-impl From<WKBDimension> for geo_traits::Dimensions {
-    fn from(value: WKBDimension) -> Self {
+impl From<Dimension> for geo_traits::Dimensions {
+    fn from(value: Dimension) -> Self {
         match value {
-            WKBDimension::Xy => Self::Xy,
-            WKBDimension::Xyz => Self::Xyz,
-            WKBDimension::Xym => Self::Xym,
-            WKBDimension::Xyzm => Self::Xyzm,
+            Dimension::Xy => Self::Xy,
+            Dimension::Xyz => Self::Xyz,
+            Dimension::Xym => Self::Xym,
+            Dimension::Xyzm => Self::Xyzm,
         }
     }
 }
@@ -94,7 +94,7 @@ impl WKBGeometryCode {
 
     pub(crate) fn get_type(&self) -> WKBResult<WKBType> {
         let code = self.0;
-        let mut dim = WKBDimension::Xy;
+        let mut dim = Dimension::Xy;
 
         // For ISO WKB:
         // Values 1, 2, 3 are 2D,
@@ -102,9 +102,9 @@ impl WKBGeometryCode {
         // 2001 etc are XYM,
         // 3001 etc are XYZM
         match code / 1000 {
-            1 => dim = WKBDimension::Xyz,
-            2 => dim = WKBDimension::Xym,
-            3 => dim = WKBDimension::Xyzm,
+            1 => dim = Dimension::Xyz,
+            2 => dim = Dimension::Xym,
+            3 => dim = Dimension::Xyzm,
             _ => (),
         };
 
@@ -113,9 +113,9 @@ impl WKBGeometryCode {
         let is_ewkb_m = code & EWKB_FLAG_M == EWKB_FLAG_M;
 
         match (is_ewkb_z, is_ewkb_m) {
-            (true, true) => dim = WKBDimension::Xyzm,
-            (true, false) => dim = WKBDimension::Xyz,
-            (false, true) => dim = WKBDimension::Xym,
+            (true, true) => dim = Dimension::Xyzm,
+            (true, false) => dim = Dimension::Xyz,
+            (false, true) => dim = Dimension::Xym,
             _ => (),
         }
 
@@ -142,19 +142,19 @@ impl WKBGeometryCode {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum WKBType {
     /// A WKB Point
-    Point(WKBDimension),
+    Point(Dimension),
     /// A WKB LineString
-    LineString(WKBDimension),
+    LineString(Dimension),
     /// A WKB Polygon
-    Polygon(WKBDimension),
+    Polygon(Dimension),
     /// A WKB MultiPoint
-    MultiPoint(WKBDimension),
+    MultiPoint(Dimension),
     /// A WKB MultiLineString
-    MultiLineString(WKBDimension),
+    MultiLineString(Dimension),
     /// A WKB MultiPolygon
-    MultiPolygon(WKBDimension),
+    MultiPolygon(Dimension),
     /// A WKB GeometryCollection
-    GeometryCollection(WKBDimension),
+    GeometryCollection(Dimension),
 }
 
 impl WKBType {

--- a/src/reader/coord.rs
+++ b/src/reader/coord.rs
@@ -1,6 +1,6 @@
 use std::io::Cursor;
 
-use crate::common::WKBDimension;
+use crate::common::Dimension;
 use crate::reader::util::ReadBytesExt;
 use crate::Endianness;
 use geo_traits::{CoordTrait, Dimensions};
@@ -31,7 +31,7 @@ pub struct Coord<'a> {
     /// `Point` objects.
     offset: u64,
 
-    dim: WKBDimension,
+    dim: Dimension,
 }
 
 impl<'a> Coord<'a> {
@@ -39,7 +39,7 @@ impl<'a> Coord<'a> {
         buf: &'a [u8],
         byte_order: Endianness,
         offset: u64,
-        dim: WKBDimension,
+        dim: Dimension,
     ) -> Self {
         Self {
             buf,

--- a/src/reader/coord.rs
+++ b/src/reader/coord.rs
@@ -35,12 +35,7 @@ pub struct Coord<'a> {
 }
 
 impl<'a> Coord<'a> {
-    pub(crate) fn new(
-        buf: &'a [u8],
-        byte_order: Endianness,
-        offset: u64,
-        dim: Dimension,
-    ) -> Self {
+    pub(crate) fn new(buf: &'a [u8], byte_order: Endianness, offset: u64, dim: Dimension) -> Self {
         Self {
             buf,
             byte_order,

--- a/src/reader/geometry.rs
+++ b/src/reader/geometry.rs
@@ -2,9 +2,7 @@ use std::io::Cursor;
 
 use byteorder::ReadBytesExt;
 
-use crate::common::{Dimension, WKBType};
-use crate::common::{WkbDimension, WkbType};
-use crate::error::WKBResult;
+use crate::common::{Dimension, WkbType};
 use crate::error::WkbResult;
 use crate::reader::{
     GeometryCollection, GeometryType, LineString, MultiLineString, MultiPoint, MultiPolygon, Point,

--- a/src/reader/geometry.rs
+++ b/src/reader/geometry.rs
@@ -2,10 +2,11 @@ use std::io::Cursor;
 
 use byteorder::ReadBytesExt;
 
-use crate::common::{WKBDimension, WKBType};
+use crate::common::{Dimension, WKBType};
 use crate::error::WKBResult;
 use crate::reader::{
-    GeometryCollection, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon,
+    GeometryCollection, GeometryType, LineString, MultiLineString, MultiPoint, MultiPolygon, Point,
+    Polygon,
 };
 use crate::Endianness;
 use geo_traits::{
@@ -40,7 +41,8 @@ impl<'a> Wkb<'a> {
         Ok(Self(inner))
     }
 
-    pub(crate) fn dimension(&self) -> WKBDimension {
+    // Return the [Dimension] of this geometry.
+    pub fn dimension(&self) -> Dimension {
         use WkbInner::*;
         match &self.0 {
             Point(g) => g.dimension(),
@@ -50,6 +52,20 @@ impl<'a> Wkb<'a> {
             MultiLineString(g) => g.dimension(),
             MultiPolygon(g) => g.dimension(),
             GeometryCollection(g) => g.dimension(),
+        }
+    }
+
+    /// Return the [GeometryType] of this geometry.
+    pub fn geometry_type(&self) -> GeometryType {
+        use WkbInner::*;
+        match &self.0 {
+            Point(_) => GeometryType::Point,
+            LineString(_) => GeometryType::LineString,
+            Polygon(_) => GeometryType::Polygon,
+            MultiPoint(_) => GeometryType::MultiPoint,
+            MultiLineString(_) => GeometryType::MultiLineString,
+            MultiPolygon(_) => GeometryType::MultiPolygon,
+            GeometryCollection(_) => GeometryType::GeometryCollection,
         }
     }
 

--- a/src/reader/geometry_collection.rs
+++ b/src/reader/geometry_collection.rs
@@ -1,6 +1,6 @@
 use std::io::Cursor;
 
-use crate::common::WKBDimension;
+use crate::common::Dimension;
 use crate::error::WKBResult;
 use crate::reader::util::{has_srid, ReadBytesExt};
 use crate::reader::Wkb;
@@ -15,12 +15,12 @@ const HEADER_BYTES: u64 = 5;
 pub struct GeometryCollection<'a> {
     /// A WKB object for each of the internal geometries
     geometries: Vec<Wkb<'a>>,
-    dim: WKBDimension,
+    dim: Dimension,
     has_srid: bool,
 }
 
 impl<'a> GeometryCollection<'a> {
-    pub fn try_new(buf: &'a [u8], byte_order: Endianness, dim: WKBDimension) -> WKBResult<Self> {
+    pub fn try_new(buf: &'a [u8], byte_order: Endianness, dim: Dimension) -> WKBResult<Self> {
         let mut offset = 0;
         let has_srid = has_srid(buf, byte_order, offset);
         if has_srid {
@@ -53,7 +53,7 @@ impl<'a> GeometryCollection<'a> {
         })
     }
 
-    pub fn dimension(&self) -> WKBDimension {
+    pub fn dimension(&self) -> Dimension {
         self.dim
     }
 

--- a/src/reader/geometry_collection.rs
+++ b/src/reader/geometry_collection.rs
@@ -20,7 +20,7 @@ pub struct GeometryCollection<'a> {
 }
 
 impl<'a> GeometryCollection<'a> {
-    pub fn try_new(buf: &'a [u8], byte_order: Endianness, dim: Dimension) -> WKBResult<Self> {
+    pub fn try_new(buf: &'a [u8], byte_order: Endianness, dim: Dimension) -> WkbResult<Self> {
         let mut offset = 0;
         let has_srid = has_srid(buf, byte_order, offset);
         if has_srid {

--- a/src/reader/linearring.rs
+++ b/src/reader/linearring.rs
@@ -1,6 +1,6 @@
 use std::io::Cursor;
 
-use crate::common::WKBDimension;
+use crate::common::Dimension;
 use crate::reader::coord::Coord;
 use crate::reader::util::ReadBytesExt;
 use crate::Endianness;
@@ -31,11 +31,11 @@ pub struct WKBLinearRing<'a> {
     /// The number of points in this linear ring
     num_points: usize,
 
-    dim: WKBDimension,
+    dim: Dimension,
 }
 
 impl<'a> WKBLinearRing<'a> {
-    pub fn new(buf: &'a [u8], byte_order: Endianness, offset: u64, dim: WKBDimension) -> Self {
+    pub fn new(buf: &'a [u8], byte_order: Endianness, offset: u64, dim: Dimension) -> Self {
         let mut reader = Cursor::new(buf);
         reader.set_position(offset);
         let num_points = reader.read_u32(byte_order).unwrap().try_into().unwrap();

--- a/src/reader/linestring.rs
+++ b/src/reader/linestring.rs
@@ -1,6 +1,6 @@
 use std::io::Cursor;
 
-use crate::common::WKBDimension;
+use crate::common::Dimension;
 use crate::reader::coord::Coord;
 use crate::reader::util::{has_srid, ReadBytesExt};
 use crate::Endianness;
@@ -23,12 +23,12 @@ pub struct LineString<'a> {
     /// This offset will be 0 for a single LineString but it will be non zero for a
     /// LineString contained within a MultiLineString
     offset: u64,
-    dim: WKBDimension,
+    dim: Dimension,
     has_srid: bool,
 }
 
 impl<'a> LineString<'a> {
-    pub fn new(buf: &'a [u8], byte_order: Endianness, mut offset: u64, dim: WKBDimension) -> Self {
+    pub fn new(buf: &'a [u8], byte_order: Endianness, mut offset: u64, dim: Dimension) -> Self {
         let has_srid = has_srid(buf, byte_order, offset);
         if has_srid {
             offset += 4;
@@ -68,7 +68,7 @@ impl<'a> LineString<'a> {
         self.offset + 1 + 4 + 4 + (self.dim.size() as u64 * 8 * i)
     }
 
-    pub fn dimension(&self) -> WKBDimension {
+    pub fn dimension(&self) -> Dimension {
         self.dim
     }
 }

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -32,3 +32,19 @@ use crate::error::WKBResult;
 pub fn read_wkb(buf: &[u8]) -> WKBResult<Wkb> {
     Wkb::try_new(buf)
 }
+
+/// The geometry type of the WKB object.
+///
+/// This is marked as non exhaustive because we do not currently support extended WKB types, such
+/// as curves.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum GeometryType {
+    Point,
+    LineString,
+    Polygon,
+    MultiPoint,
+    MultiLineString,
+    MultiPolygon,
+    GeometryCollection,
+}

--- a/src/reader/multilinestring.rs
+++ b/src/reader/multilinestring.rs
@@ -1,6 +1,6 @@
 use std::io::Cursor;
 
-use crate::common::WKBDimension;
+use crate::common::Dimension;
 use crate::reader::linestring::LineString;
 use crate::reader::util::{has_srid, ReadBytesExt};
 use crate::Endianness;
@@ -16,12 +16,12 @@ const HEADER_BYTES: u64 = 5;
 pub struct MultiLineString<'a> {
     /// A LineString object for each of the internal line strings
     wkb_line_strings: Vec<LineString<'a>>,
-    dim: WKBDimension,
+    dim: Dimension,
     has_srid: bool,
 }
 
 impl<'a> MultiLineString<'a> {
-    pub(crate) fn new(buf: &'a [u8], byte_order: Endianness, dim: WKBDimension) -> Self {
+    pub(crate) fn new(buf: &'a [u8], byte_order: Endianness, dim: Dimension) -> Self {
         let mut offset = 0;
         let has_srid = has_srid(buf, byte_order, offset);
         if has_srid {
@@ -71,7 +71,7 @@ impl<'a> MultiLineString<'a> {
             .fold(header, |acc, ls| acc + ls.size())
     }
 
-    pub fn dimension(&self) -> WKBDimension {
+    pub fn dimension(&self) -> Dimension {
         self.dim
     }
 }

--- a/src/reader/multipoint.rs
+++ b/src/reader/multipoint.rs
@@ -1,6 +1,6 @@
 use std::io::Cursor;
 
-use crate::common::WKBDimension;
+use crate::common::Dimension;
 use crate::reader::point::Point;
 use crate::reader::util::{has_srid, ReadBytesExt};
 use crate::Endianness;
@@ -17,12 +17,12 @@ pub struct MultiPoint<'a> {
 
     /// The number of points in this multi point
     num_points: usize,
-    dim: WKBDimension,
+    dim: Dimension,
     has_srid: bool,
 }
 
 impl<'a> MultiPoint<'a> {
-    pub(crate) fn new(buf: &'a [u8], byte_order: Endianness, dim: WKBDimension) -> Self {
+    pub(crate) fn new(buf: &'a [u8], byte_order: Endianness, dim: Dimension) -> Self {
         let mut offset = 0;
         let has_srid = has_srid(buf, byte_order, offset);
         if has_srid {
@@ -70,7 +70,7 @@ impl<'a> MultiPoint<'a> {
         header + ((1 + 4 + (self.dim.size() as u64 * 8)) * i)
     }
 
-    pub fn dimension(&self) -> WKBDimension {
+    pub fn dimension(&self) -> Dimension {
         self.dim
     }
 }

--- a/src/reader/multipolygon.rs
+++ b/src/reader/multipolygon.rs
@@ -1,6 +1,6 @@
 use std::io::Cursor;
 
-use crate::common::WKBDimension;
+use crate::common::Dimension;
 use crate::reader::polygon::Polygon;
 use crate::reader::util::{has_srid, ReadBytesExt};
 use crate::Endianness;
@@ -16,12 +16,12 @@ pub struct MultiPolygon<'a> {
     /// A Polygon object for each of the internal line strings
     wkb_polygons: Vec<Polygon<'a>>,
 
-    dim: WKBDimension,
+    dim: Dimension,
     has_srid: bool,
 }
 
 impl<'a> MultiPolygon<'a> {
-    pub(crate) fn new(buf: &'a [u8], byte_order: Endianness, dim: WKBDimension) -> Self {
+    pub(crate) fn new(buf: &'a [u8], byte_order: Endianness, dim: Dimension) -> Self {
         let mut offset = 0;
         let has_srid = has_srid(buf, byte_order, offset);
         if has_srid {
@@ -70,7 +70,7 @@ impl<'a> MultiPolygon<'a> {
             .fold(header, |acc, x| acc + x.size())
     }
 
-    pub fn dimension(&self) -> WKBDimension {
+    pub fn dimension(&self) -> Dimension {
         self.dim
     }
 }

--- a/src/reader/point.rs
+++ b/src/reader/point.rs
@@ -1,4 +1,4 @@
-use crate::common::WKBDimension;
+use crate::common::Dimension;
 use crate::reader::coord::Coord;
 use crate::reader::util::has_srid;
 use crate::Endianness;
@@ -14,18 +14,13 @@ use geo_traits::{CoordTrait, PointTrait};
 pub struct Point<'a> {
     /// The coordinate inside this Point
     coord: Coord<'a>,
-    dim: WKBDimension,
+    dim: Dimension,
     is_empty: bool,
     has_srid: bool,
 }
 
 impl<'a> Point<'a> {
-    pub(crate) fn new(
-        buf: &'a [u8],
-        byte_order: Endianness,
-        offset: u64,
-        dim: WKBDimension,
-    ) -> Self {
+    pub(crate) fn new(buf: &'a [u8], byte_order: Endianness, offset: u64, dim: Dimension) -> Self {
         let has_srid = has_srid(buf, byte_order, offset);
 
         // The space of the byte order + geometry type
@@ -67,7 +62,7 @@ impl<'a> Point<'a> {
         header + (self.dim.size() as u64 * 8)
     }
 
-    pub fn dimension(&self) -> WKBDimension {
+    pub fn dimension(&self) -> Dimension {
         self.dim
     }
 }

--- a/src/reader/polygon.rs
+++ b/src/reader/polygon.rs
@@ -1,6 +1,6 @@
 use std::io::Cursor;
 
-use crate::common::WKBDimension;
+use crate::common::Dimension;
 use crate::reader::linearring::WKBLinearRing;
 use crate::reader::util::{has_srid, ReadBytesExt};
 use crate::Endianness;
@@ -16,12 +16,12 @@ const HEADER_BYTES: u64 = 5;
 #[derive(Debug, Clone)]
 pub struct Polygon<'a> {
     wkb_linear_rings: Vec<WKBLinearRing<'a>>,
-    dim: WKBDimension,
+    dim: Dimension,
     has_srid: bool,
 }
 
 impl<'a> Polygon<'a> {
-    pub fn new(buf: &'a [u8], byte_order: Endianness, mut offset: u64, dim: WKBDimension) -> Self {
+    pub fn new(buf: &'a [u8], byte_order: Endianness, mut offset: u64, dim: Dimension) -> Self {
         let has_srid = has_srid(buf, byte_order, offset);
         if has_srid {
             offset += 4;
@@ -69,7 +69,7 @@ impl<'a> Polygon<'a> {
             .fold(header, |acc, ring| acc + ring.size())
     }
 
-    pub fn dimension(&self) -> WKBDimension {
+    pub fn dimension(&self) -> Dimension {
         self.dim
     }
 }

--- a/src/reader/polygon.rs
+++ b/src/reader/polygon.rs
@@ -1,7 +1,7 @@
 use std::io::Cursor;
 
 use crate::common::Dimension;
-use crate::reader::linearring::WKBLinearRing;
+use crate::reader::linearring::LinearRing;
 use crate::reader::util::{has_srid, ReadBytesExt};
 use crate::Endianness;
 use geo_traits::Dimensions;


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
- [x] I ran cargo fmt
---

### Change list

- add `dimension` and `geometry_type` methods to `Wkb`
- Add `GeometryType` enum
- Rename `WKBDimension` to `Dimension`

Closes https://github.com/georust/wkb/issues/58, closes https://github.com/georust/wkb/issues/60