### PR TITLE
Remove `WKBType` from public API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,4 +7,4 @@ pub mod reader;
 mod test;
 pub mod writer;
 
-pub use common::{Endianness, WKBType};
+pub use common::Endianness;


### PR DESCRIPTION
- [ ] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
- [ ] I ran cargo fmt
---

`WKBType` is currently unusable anyways as it isn't returned or accepted as a parameter by any public API. 

Another option here is to keep `WKBType` instead of https://github.com/georust/wkb/pull/65. I.e. instead of having separate geometry type and dimension enums, we could have a single geometry type enum that contains the dimension. But IMO it's cleaner to have two separate enums.

Closes https://github.com/georust/wkb/issues/48