### PR TITLE
Bump `wkt` dev dependency to 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ bytes = "1.5.0"
 criterion = { version = "0.5", features = ["html_reports"] }
 geo-types = "0.7.13"
 geos = { version = "10", features = ["geo"] }
-wkt = "0.12"
+wkt = { version = "0.13", features = ["geo-types"] }
 
 [[bench]]
 name = "parse"

--- a/benches/brect.rs
+++ b/benches/brect.rs
@@ -1,16 +1,14 @@
-use std::str::FromStr;
-
 use criterion::{criterion_group, criterion_main};
 use geo_traits::{CoordTrait, GeometryTrait, GeometryType, LineStringTrait, PolygonTrait};
-use geo_types::coord;
-use wkt::Wkt;
+use geo_types::{coord, Geometry};
+use wkt::TryFromWkt;
 
-fn load_small_wkt() -> Wkt<f64> {
+fn load_small_wkt() -> Geometry {
     let s = include_str!("./small.wkt");
-    Wkt::from_str(s).unwrap()
+    Geometry::try_from_wkt_str(s).unwrap()
 }
 
-fn to_wkb(geom: &Wkt<f64>) -> Vec<u8> {
+fn to_wkb(geom: &Geometry) -> Vec<u8> {
     let mut buffer = Vec::new();
     wkb::writer::write_geometry(&mut buffer, geom, Default::default()).unwrap();
     buffer

--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -1,20 +1,19 @@
-use std::str::FromStr;
-
 use criterion::{criterion_group, criterion_main};
 use geo_traits::to_geo::ToGeoGeometry;
-use wkt::Wkt;
+use geo_types::Geometry;
+use wkt::TryFromWkt;
 
-fn load_small_wkt() -> Wkt<f64> {
+fn load_small_wkt() -> Geometry {
     let s = include_str!("./small.wkt");
-    Wkt::from_str(s).unwrap()
+    Geometry::try_from_wkt_str(s).unwrap()
 }
 
-fn load_big_wkt() -> Wkt<f64> {
+fn load_big_wkt() -> Geometry {
     let s = include_str!("./big.wkt");
-    Wkt::from_str(s).unwrap()
+    Geometry::try_from_wkt_str(s).unwrap()
 }
 
-fn to_wkb(geom: &Wkt<f64>) -> Vec<u8> {
+fn to_wkb(geom: &Geometry) -> Vec<u8> {
     let mut buffer = Vec::new();
     wkb::writer::write_geometry(&mut buffer, geom, Default::default()).unwrap();
     buffer


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
- [x] I ran cargo fmt
---

The `wkt` crate is currently only used in the two benchmarking scripts.

### Change list

- Bump `wkt` to 0.13
- Add `geo-types` feature to avoid using the geo-traits APIs of the `wkt` crate. This means we can independently bump the version of `geo-traits` here in `wkb` separately from in `wkt`.