### PR TITLE
Don't panic when parsing invalid WKB using `Wkb::try_new`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Your change here.
+- Don't panic when parsing invalid WKB (#74).
 
 ## 0.9.0 - 2025-05-14
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -161,10 +161,10 @@ impl WkbType {
     /// Construct from a byte slice representing a WKB geometry
     pub(crate) fn from_buffer(buf: &[u8]) -> WkbResult<Self> {
         let mut reader = Cursor::new(buf);
-        let byte_order = reader.read_u8().unwrap();
+        let byte_order = reader.read_u8()?;
         let geometry_code = match byte_order {
-            0 => reader.read_u32::<BigEndian>().unwrap(),
-            1 => reader.read_u32::<LittleEndian>().unwrap(),
+            0 => reader.read_u32::<BigEndian>()?,
+            1 => reader.read_u32::<LittleEndian>()?,
             other => {
                 return Err(WkbError::General(format!(
                     "Unexpected byte order: {}",

--- a/src/reader/util.rs
+++ b/src/reader/util.rs
@@ -1,7 +1,6 @@
 use byteorder::{BigEndian, LittleEndian};
 
-use crate::common::WkbGeometryCode;
-use crate::Endianness;
+use crate::{common::WkbGeometryCode, error::WkbError, Endianness};
 use std::io::{Cursor, Error};
 
 pub(crate) trait ReadBytesExt: byteorder::ReadBytesExt {
@@ -25,13 +24,13 @@ pub(crate) trait ReadBytesExt: byteorder::ReadBytesExt {
 impl<R: std::io::Read + ?Sized> ReadBytesExt for R {}
 
 /// Return `true` if this WKB item is EWKB and has an embedded SRID
-pub(crate) fn has_srid(buf: &[u8], byte_order: Endianness, offset: u64) -> bool {
+pub(crate) fn has_srid(buf: &[u8], byte_order: Endianness, offset: u64) -> Result<bool, WkbError> {
     // Read geometry code to see if an SRID exists.
     let mut reader = Cursor::new(buf);
 
     // Skip 1-byte byte order that we already know
     reader.set_position(1 + offset);
 
-    let geometry_code = WkbGeometryCode::new(reader.read_u32(byte_order).unwrap());
-    geometry_code.has_srid()
+    let geometry_code = WkbGeometryCode::new(reader.read_u32(byte_order)?);
+    Ok(geometry_code.has_srid())
 }

--- a/src/test/invalid_ewkb.rs
+++ b/src/test/invalid_ewkb.rs
@@ -1,0 +1,143 @@
+#[cfg(test)]
+mod tests {
+    use crate::reader::Wkb;
+
+    const Z_FLAG: u32 = 0x80000000;
+    const M_FLAG: u32 = 0x40000000;
+    const SRID_FLAG: u32 = 0x20000000;
+
+    // --- Helper Functions ---
+    fn make_ewkb_header(
+        type_id_base: u32,
+        has_z: bool,
+        has_m: bool,
+        has_srid: bool,
+        is_little_endian: bool,
+    ) -> Vec<u8> {
+        let mut type_val = type_id_base;
+        if has_z {
+            type_val |= Z_FLAG;
+        }
+        if has_m {
+            type_val |= M_FLAG;
+        }
+        if has_srid {
+            type_val |= SRID_FLAG;
+        }
+
+        let mut header = vec![if is_little_endian { 0x01 } else { 0x00 }];
+        if is_little_endian {
+            header.extend_from_slice(&type_val.to_le_bytes());
+        } else {
+            header.extend_from_slice(&type_val.to_be_bytes());
+        }
+        header
+    }
+
+    fn srid_bytes(srid: u32, is_little_endian: bool) -> [u8; 4] {
+        if is_little_endian {
+            srid.to_le_bytes()
+        } else {
+            srid.to_be_bytes()
+        }
+    }
+
+    // --- EWKB Point Errors ---
+    #[test]
+    fn test_ewkb_point_srid_flag_but_no_srid_data() {
+        let mut ewkb_data = make_ewkb_header(1, false, false, true, true); // Point XY, with SRID flag, LE
+                                                                           // Missing SRID data (4 bytes), then coords should start
+        ewkb_data.extend_from_slice(&1.0f64.to_le_bytes()); // X
+        ewkb_data.extend_from_slice(&2.0f64.to_le_bytes()); // Y
+        let result = Wkb::try_new(&ewkb_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_ewkb_point_srid_flag_buffer_too_short_for_srid_value() {
+        let mut ewkb_data = make_ewkb_header(1, false, false, true, true); // Point XY, with SRID flag, LE
+        ewkb_data.extend_from_slice(&[0u8; 2]); // Only 2 bytes for SRID, needs 4
+        let result = Wkb::try_new(&ewkb_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_ewkb_point_with_srid_buffer_too_short_for_coords() {
+        let mut ewkb_data = make_ewkb_header(1, false, false, true, true); // Point XY, with SRID flag, LE
+        ewkb_data.extend_from_slice(&srid_bytes(4326, true)); // SRID (4 bytes)
+        ewkb_data.extend_from_slice(&[0u8; 8]); // Only 8 bytes for coords, need 16
+        let result = Wkb::try_new(&ewkb_data);
+        assert!(result.is_err());
+    }
+
+    // --- EWKB LineString Errors ---
+    #[test]
+    fn test_ewkb_linestring_with_srid_buffer_too_short_for_num_points() {
+        let mut ewkb_data = make_ewkb_header(2, false, false, true, true); // LineString XY, SRID, LE
+        ewkb_data.extend_from_slice(&srid_bytes(4326, true)); // SRID (4 bytes)
+                                                              // num_points field (4 bytes) is missing
+        let result = Wkb::try_new(&ewkb_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_ewkb_linestring_with_srid_num_points_too_large_for_buffer() {
+        let mut ewkb_data = make_ewkb_header(2, false, false, true, true); // LineString XY, SRID, LE
+        ewkb_data.extend_from_slice(&srid_bytes(4326, true)); // SRID (4 bytes)
+        ewkb_data.extend_from_slice(&10u32.to_le_bytes()); // 10 points declared
+        ewkb_data.extend_from_slice(&1.0f64.to_le_bytes()); // Only 1 point's data (16 bytes)
+        ewkb_data.extend_from_slice(&2.0f64.to_le_bytes());
+        let result = Wkb::try_new(&ewkb_data);
+        assert!(result.is_err());
+    }
+
+    // --- EWKB Polygon Errors ---
+    #[test]
+    fn test_ewkb_polygon_with_srid_buffer_too_short_for_num_rings() {
+        let mut ewkb_data = make_ewkb_header(3, false, false, true, true); // Polygon XY, SRID, LE
+        ewkb_data.extend_from_slice(&srid_bytes(4326, true)); // SRID (4 bytes)
+                                                              // num_rings field (4 bytes) is missing
+        let result = Wkb::try_new(&ewkb_data);
+        assert!(result.is_err());
+    }
+
+    // --- EWKB MultiPoint Errors ---
+    #[test]
+    fn test_ewkb_multipoint_srid_flag_but_no_srid_data_for_outer_geom() {
+        let mut ewkb_data = make_ewkb_header(4, false, false, true, true); // MultiPoint XY, SRID, LE
+                                                                           // Outer SRID missing
+        ewkb_data.extend_from_slice(&1u32.to_le_bytes()); // 1 point
+                                                          // Contained point (must also have its own header, potentially SRID)
+        let mut contained_point = make_ewkb_header(1, false, false, false, true); // Point XY, no SRID, LE
+        contained_point.extend_from_slice(&1.0f64.to_le_bytes());
+        contained_point.extend_from_slice(&2.0f64.to_le_bytes());
+        ewkb_data.extend(contained_point);
+        let result = Wkb::try_new(&ewkb_data);
+        assert!(result.is_err());
+    }
+
+    // --- Z/M Dimension Mismatch (EWKB specific example) ---
+    #[test]
+    fn test_ewkb_point_xyz_flag_but_xy_data() {
+        let mut ewkb_data = make_ewkb_header(1, true, false, false, true); // Point XYZ (Z_FLAG), no SRID, LE
+        ewkb_data.extend_from_slice(&1.0f64.to_le_bytes()); // X
+        ewkb_data.extend_from_slice(&2.0f64.to_le_bytes()); // Y
+                                                            // Missing Z coordinate (8 bytes)
+        let result = Wkb::try_new(&ewkb_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_ewkb_linestring_xyzm_flag_but_xyz_data_for_points() {
+        let type_id_base = 2; // LineString
+        let mut ewkb_data = make_ewkb_header(type_id_base, true, true, false, true); // LineString XYZM, no SRID, LE
+        ewkb_data.extend_from_slice(&1u32.to_le_bytes()); // 1 point
+                                                          // Coords for 1 point (XYZM = 32 bytes expected per point)
+        ewkb_data.extend_from_slice(&1.0f64.to_le_bytes()); // X
+        ewkb_data.extend_from_slice(&2.0f64.to_le_bytes()); // Y
+        ewkb_data.extend_from_slice(&3.0f64.to_le_bytes()); // Z
+                                                            // Missing M coordinate (8 bytes)
+        let result = Wkb::try_new(&ewkb_data);
+        assert!(result.is_err());
+    }
+}

--- a/src/test/invalid_wkb.rs
+++ b/src/test/invalid_wkb.rs
@@ -1,0 +1,200 @@
+#[cfg(test)]
+mod tests {
+    use crate::reader::Wkb;
+
+    // --- Helper Functions ---
+    fn make_wkb_header(type_id: u32, is_little_endian: bool) -> Vec<u8> {
+        let mut header = vec![if is_little_endian { 0x01 } else { 0x00 }];
+        if is_little_endian {
+            header.extend_from_slice(&type_id.to_le_bytes());
+        } else {
+            header.extend_from_slice(&type_id.to_be_bytes());
+        }
+        header
+    }
+
+    // --- General WKB Errors ---
+    #[test]
+    fn test_wkb_invalid_byte_order() {
+        let wkb_data = vec![0x02, 0x01, 0x00, 0x00, 0x00]; // Invalid byte order 0x02
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_wkb_buffer_too_short_for_header() {
+        let wkb_data = vec![0x01, 0x01, 0x00]; // Only 3 bytes, header needs 5
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    // --- Point WKB Errors ---
+    #[test]
+    fn test_wkb_point_xy_buffer_too_short_for_coords() {
+        let mut wkb_data = make_wkb_header(1, true); // Point XY, LE = 5 bytes
+        wkb_data.extend_from_slice(&[0u8; 8]); // Only 8 bytes for coords, need 16
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_wkb_point_xyz_buffer_too_short_for_coords() {
+        let mut wkb_data = make_wkb_header(1001, true); // Point XYZ, LE = 5 bytes
+        wkb_data.extend_from_slice(&[0u8; 16]); // Only 16 bytes for coords, need 24
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    // --- LineString WKB Errors ---
+    #[test]
+    fn test_wkb_linestring_buffer_too_short_for_num_points() {
+        let wkb_data = make_wkb_header(2, true); // LineString XY, LE = 5 bytes
+                                                 // Missing num_points field (4 bytes)
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_wkb_linestring_num_points_too_large_for_buffer() {
+        let mut wkb_data = make_wkb_header(2, true); // LineString XY, LE = 5 bytes
+        wkb_data.extend_from_slice(&10u32.to_le_bytes()); // 10 points declared
+        wkb_data.extend_from_slice(&1.0f64.to_le_bytes()); // Only 1 point's data (16 bytes)
+        wkb_data.extend_from_slice(&2.0f64.to_le_bytes());
+        // Total 5 + 4 + 16 = 25 bytes. Expected 5 + 4 + 10*16 = 169 bytes.
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_wkb_linestring_invalid_num_points_value() {
+        let mut wkb_data = make_wkb_header(2, true); // LineString XY, LE
+                                                     // u32::MAX num_points would cause massive size calculation if not for try_into error first
+        wkb_data.extend_from_slice(&u32::MAX.to_le_bytes());
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    // --- Polygon WKB Errors ---
+    #[test]
+    fn test_wkb_polygon_buffer_too_short_for_num_rings() {
+        let wkb_data = make_wkb_header(3, true); // Polygon XY, LE = 5 bytes
+                                                 // Missing num_rings field (4 bytes)
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_wkb_polygon_buffer_too_short_for_ring_num_points() {
+        let mut wkb_data = make_wkb_header(3, true); // Polygon XY, LE
+        wkb_data.extend_from_slice(&1u32.to_le_bytes()); // 1 ring
+                                                         // Missing num_points for the ring (4 bytes)
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_wkb_polygon_ring_num_points_too_large_for_buffer() {
+        let mut wkb_data = make_wkb_header(3, true); // Polygon XY, LE
+        wkb_data.extend_from_slice(&1u32.to_le_bytes()); // 1 ring
+        wkb_data.extend_from_slice(&4u32.to_le_bytes()); // Ring has 4 points (closed)
+                                                         // Provide data for only 1 point (16 bytes)
+        wkb_data.extend_from_slice(&0.0f64.to_le_bytes());
+        wkb_data.extend_from_slice(&0.0f64.to_le_bytes());
+        // Expected: 5 (poly header) + 4 (num_rings) + 4 (ring num_points) + 4*16 (coords) = 77
+        // Actual:   5 + 4 + 4 + 16 = 29
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    // --- MultiPoint WKB Errors ---
+    #[test]
+    fn test_wkb_multipoint_buffer_too_short_for_num_multipoints_header() {
+        let wkb_data = make_wkb_header(4, true); // MultiPoint XY, LE = 5 bytes
+                                                 // Missing num_points for MultiPoint itself (4 bytes)
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_wkb_multipoint_buffer_too_short_for_contained_point_header() {
+        let mut wkb_data = make_wkb_header(4, true); // MultiPoint XY, LE
+        wkb_data.extend_from_slice(&1u32.to_le_bytes()); // 1 point in multipoint
+                                                         // Missing the contained point's WKB header (5 bytes: 1 byte order + 4 type)
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_wkb_multipoint_buffer_too_short_for_contained_point_coords() {
+        let mut wkb_data = make_wkb_header(4, true); // MultiPoint XY, LE
+        wkb_data.extend_from_slice(&1u32.to_le_bytes()); // 1 point in multipoint
+        wkb_data.extend(make_wkb_header(1, true)); // Contained Point XY header (5 bytes)
+        wkb_data.extend_from_slice(&[0u8; 8]); // Only 8 bytes for contained point's coords, needs 16
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    // --- MultiLineString WKB Errors ---
+    #[test]
+    fn test_wkb_multilinestring_buffer_too_short_for_num_multilinestrings_header() {
+        let wkb_data = make_wkb_header(5, true); // MultiLineString XY, LE = 5 bytes
+                                                 // Missing num_linestrings for MultiLineString itself (4 bytes)
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_wkb_multilinestring_buffer_too_short_for_contained_linestring_header() {
+        let mut wkb_data = make_wkb_header(5, true); // MultiLineString XY, LE
+        wkb_data.extend_from_slice(&1u32.to_le_bytes()); // 1 linestring
+                                                         // Missing contained linestring's WKB header (5 bytes)
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_wkb_multilinestring_buffer_too_short_for_contained_linestring_num_points() {
+        let mut wkb_data = make_wkb_header(5, true); // MultiLineString XY, LE
+        wkb_data.extend_from_slice(&1u32.to_le_bytes()); // 1 linestring
+        wkb_data.extend(make_wkb_header(2, true)); // Contained LineString XY header (5 bytes)
+                                                   // Missing contained linestring's num_points (4 bytes)
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    // --- MultiPolygon WKB Errors ---
+    #[test]
+    fn test_wkb_multipolygon_buffer_too_short_for_num_multipolygons_header() {
+        let wkb_data = make_wkb_header(6, true); // MultiPolygon XY, LE = 5 bytes
+                                                 // Missing num_polygons for MultiPolygon itself (4 bytes)
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_wkb_multipolygon_buffer_too_short_for_contained_polygon_header() {
+        let mut wkb_data = make_wkb_header(6, true); // MultiPolygon XY, LE
+        wkb_data.extend_from_slice(&1u32.to_le_bytes()); // 1 polygon
+                                                         // Missing contained polygon's WKB header (5 bytes)
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    // --- GeometryCollection WKB Errors ---
+    #[test]
+    fn test_wkb_geomcollection_buffer_too_short_for_num_geometries_header() {
+        let wkb_data = make_wkb_header(7, true); // GeometryCollection XY, LE = 5 bytes
+                                                 // Missing num_geometries for GeometryCollection itself (4 bytes)
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_wkb_geomcollection_buffer_too_short_for_contained_geometry_header() {
+        let mut wkb_data = make_wkb_header(7, true); // GeometryCollection XY, LE
+        wkb_data.extend_from_slice(&1u32.to_le_bytes()); // 1 geometry
+                                                         // Missing contained geometry's WKB header (e.g., a Point, 5 bytes)
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+}

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,3 +1,5 @@
 mod data;
 mod ewkb;
+mod invalid_ewkb;
+mod invalid_wkb;
 mod wkb;


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
- [x] I ran cargo fmt
---

There are lots of usages of `.unwrap` in the constructors of WKB geometry values, this will make the program panic when parsing invalid geometries. Properly handling invalid WKB without panicking should be a very basic feature of georust/wkb since the user of this crate may want to handle or recover from input errors instead of panicking, so we submit this PR to return `Err` to give the caller of `Wkb::try_new` a chance to handle the error.

This PR should have minimal impact on the API, since `Wkb::try_new` already returns a `Result<..>`. This PR just propagates the errors to the return value instead of panicking inside of `try_new`. The performance of WKB parsing will be slightly affected. However, the typical workload dealing with parsed Wkb values involves traversing the coordinates and converting the Wkb values to geo_types geometry values, so the extra performance overhead of error handing in `Wkb::try_new` should not be a problem.

```
parse small             time:   [31.698 ns 31.750 ns 31.800 ns]
                        change: [+11.677% +11.987% +12.298%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 13 outliers among 100 measurements (13.00%)
  7 (7.00%) high mild
  6 (6.00%) high severe

parse big               time:   [11.518 µs 11.525 µs 11.532 µs]
                        change: [+7.2748% +7.7087% +8.0417%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 13 outliers among 100 measurements (13.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  11 (11.00%) high severe

parse small to geo      time:   [120.63 ns 120.74 ns 120.87 ns]
                        change: [+1.2419% +1.4123% +1.5739%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe

parse big to geo        time:   [143.52 µs 144.07 µs 144.63 µs]
                        change: [+1.9288% +2.6385% +3.4313%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe

```