### PR TITLE
fix: Remove trait wrappers to work around Rust 1.90 compiler regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Don't panic when parsing invalid WKB (#74).
 - Fix CI by removing georust container & fix clippy lint (#140)
+- Remove trait wrappers to work around Rust 1.90 compiler regression (#77)
 
 ## 0.9.0 - 2025-05-14
 

--- a/src/writer/line.rs
+++ b/src/writer/line.rs
@@ -1,40 +1,18 @@
-use std::io::Write;
-
-use geo_traits::{
-    GeometryTrait, LineStringTrait, LineTrait, UnimplementedGeometryCollection, UnimplementedLine,
-    UnimplementedMultiLineString, UnimplementedMultiPoint, UnimplementedMultiPolygon,
-    UnimplementedPoint, UnimplementedPolygon, UnimplementedRect, UnimplementedTriangle,
-};
-
+use crate::common::WkbType;
 use crate::error::WkbResult;
-use crate::writer::{line_string_wkb_size, write_line_string, WriteOptions};
-
-/// A wrapper around an impl LineTrait to provide LineStringTrait
-struct LineWrapper<'a, G: LineTrait<T = f64>>(&'a G);
-
-impl<'a, G: LineTrait<T = f64>> LineStringTrait for LineWrapper<'a, G> {
-    type CoordType<'b>
-        = G::CoordType<'a>
-    where
-        G: 'b,
-        Self: 'b;
-
-    fn num_coords(&self) -> usize {
-        2
-    }
-
-    unsafe fn coord_unchecked(&self, i: usize) -> Self::CoordType<'_> {
-        match i {
-            0 => self.0.start(),
-            1 => self.0.end(),
-            _ => unreachable!(),
-        }
-    }
-}
+use crate::writer::coord::write_coord;
+use crate::writer::WriteOptions;
+use crate::Endianness;
+use byteorder::{BigEndian, ByteOrder, LittleEndian, WriteBytesExt};
+use geo_traits::LineTrait;
+use std::io::Write;
 
 /// The number of bytes this Line will take up when encoded as WKB
 pub fn line_wkb_size(geom: &impl LineTrait<T = f64>) -> usize {
-    line_string_wkb_size(&LineWrapper(geom))
+    let header = 1 + 4 + 4;
+    let each_coord = geom.dim().size() * 8;
+    let all_coords = 2 * each_coord;
+    header + all_coords
 }
 
 /// Write a Line geometry to a Writer encoded as WKB
@@ -43,71 +21,29 @@ pub fn write_line(
     geom: &impl LineTrait<T = f64>,
     options: &WriteOptions,
 ) -> WkbResult<()> {
-    write_line_string(writer, &LineWrapper(geom), options)
+    // Byte order
+    writer.write_u8(options.endianness.into()).unwrap();
+
+    // Content
+    match options.endianness {
+        Endianness::LittleEndian => write_line_content::<LittleEndian>(writer, geom),
+        Endianness::BigEndian => write_line_content::<BigEndian>(writer, geom),
+    }
 }
 
-impl<G: LineTrait<T = f64>> GeometryTrait for LineWrapper<'_, G> {
-    type T = f64;
-    type PointType<'b>
-        = UnimplementedPoint<f64>
-    where
-        Self: 'b;
-    type LineStringType<'b>
-        = Self
-    where
-        Self: 'b;
-    type PolygonType<'b>
-        = UnimplementedPolygon<f64>
-    where
-        Self: 'b;
-    type MultiPointType<'b>
-        = UnimplementedMultiPoint<f64>
-    where
-        Self: 'b;
-    type MultiLineStringType<'b>
-        = UnimplementedMultiLineString<f64>
-    where
-        Self: 'b;
-    type MultiPolygonType<'b>
-        = UnimplementedMultiPolygon<f64>
-    where
-        Self: 'b;
-    type GeometryCollectionType<'b>
-        = UnimplementedGeometryCollection<f64>
-    where
-        Self: 'b;
-    type RectType<'b>
-        = UnimplementedRect<f64>
-    where
-        Self: 'b;
-    type LineType<'b>
-        = UnimplementedLine<f64>
-    where
-        Self: 'b;
-    type TriangleType<'b>
-        = UnimplementedTriangle<f64>
-    where
-        Self: 'b;
+fn write_line_content<B: ByteOrder>(
+    writer: &mut impl Write,
+    geom: &impl LineTrait<T = f64>,
+) -> WkbResult<()> {
+    let wkb_type = WkbType::LineString(geom.dim().try_into()?);
+    writer.write_u32::<B>(wkb_type.into())?;
 
-    fn dim(&self) -> geo_traits::Dimensions {
-        self.0.dim()
+    // numPoints
+    writer.write_u32::<B>(2).unwrap();
+
+    for coord in geom.coords() {
+        write_coord::<B>(writer, &coord)?;
     }
 
-    fn as_type(
-        &self,
-    ) -> geo_traits::GeometryType<
-        '_,
-        Self::PointType<'_>,
-        Self::LineStringType<'_>,
-        Self::PolygonType<'_>,
-        Self::MultiPointType<'_>,
-        Self::MultiLineStringType<'_>,
-        Self::MultiPolygonType<'_>,
-        Self::GeometryCollectionType<'_>,
-        Self::RectType<'_>,
-        Self::TriangleType<'_>,
-        Self::LineType<'_>,
-    > {
-        geo_traits::GeometryType::LineString(self)
-    }
+    Ok(())
 }

--- a/src/writer/rect.rs
+++ b/src/writer/rect.rs
@@ -1,250 +1,92 @@
+use crate::common::WkbType;
+use crate::error::WkbResult;
+use crate::writer::WriteOptions;
+use crate::Endianness;
+use byteorder::{BigEndian, ByteOrder, LittleEndian, WriteBytesExt};
+use geo_traits::{CoordTrait, RectTrait};
 use std::io::Write;
 
-use geo_traits::{
-    CoordTrait, GeometryTrait, LineStringTrait, PolygonTrait, RectTrait,
-    UnimplementedGeometryCollection, UnimplementedLine, UnimplementedLineString,
-    UnimplementedMultiLineString, UnimplementedMultiPoint, UnimplementedMultiPolygon,
-    UnimplementedPoint, UnimplementedPolygon, UnimplementedRect, UnimplementedTriangle,
-};
-
-use crate::error::WkbResult;
-use crate::writer::{polygon_wkb_size, write_polygon, WriteOptions};
-
-struct Coord2D {
-    x: f64,
-    y: f64,
-}
-
-impl CoordTrait for Coord2D {
-    type T = f64;
-
-    fn x(&self) -> Self::T {
-        self.x
-    }
-
-    fn y(&self) -> Self::T {
-        self.y
-    }
-
-    fn dim(&self) -> geo_traits::Dimensions {
-        geo_traits::Dimensions::Xy
-    }
-
-    fn nth_or_panic(&self, n: usize) -> Self::T {
-        match n {
-            0 => self.x,
-            1 => self.y,
-            _ => panic!(),
-        }
-    }
-}
-
-/// A wrapper around an impl RectTrait to provide LineStringTrait and PolygonTrait
-struct RectWrapper<'a, G: RectTrait<T = f64>>(&'a G);
-
-impl<'a, G: RectTrait<T = f64>> LineStringTrait for &'a RectWrapper<'a, G> {
-    type CoordType<'b>
-        = Coord2D
-    where
-        G: 'b,
-        Self: 'b;
-
-    fn num_coords(&self) -> usize {
-        5
-    }
-
-    unsafe fn coord_unchecked(&self, i: usize) -> Self::CoordType<'_> {
-        let min_coord = self.0.min();
-        let max_coord = self.0.max();
-
-        match i {
-            0 => Coord2D {
-                x: min_coord.x(),
-                y: min_coord.y(),
-            },
-            1 => Coord2D {
-                x: min_coord.x(),
-                y: max_coord.y(),
-            },
-            2 => Coord2D {
-                x: max_coord.x(),
-                y: max_coord.y(),
-            },
-            3 => Coord2D {
-                x: max_coord.x(),
-                y: min_coord.y(),
-            },
-            4 => Coord2D {
-                x: min_coord.x(),
-                y: min_coord.y(),
-            },
-            _ => unreachable!(),
-        }
-    }
-}
-
-impl<G: RectTrait<T = f64>> PolygonTrait for RectWrapper<'_, G> {
-    type RingType<'b>
-        = &'b RectWrapper<'b, G>
-    where
-        G: 'b,
-        Self: 'b;
-
-    fn exterior(&self) -> Option<Self::RingType<'_>> {
-        Some(self)
-    }
-
-    fn num_interiors(&self) -> usize {
-        0
-    }
-
-    unsafe fn interior_unchecked(&self, _i: usize) -> Self::RingType<'_> {
-        unreachable!()
-    }
-}
-
 /// The number of bytes this Rect will take up when encoded as WKB
+///
+/// Note that only 2D Rects are supported. Even if the input Rect has more than 2 dimensions, only
+/// the X and Y dimensions will be written.
 pub fn rect_wkb_size(geom: &impl RectTrait<T = f64>) -> usize {
-    polygon_wkb_size(&RectWrapper(geom))
+    let header = 1 + 4 + 4;
+    let each_coord = geom.dim().size() * 8;
+    let all_coords = 5 * each_coord;
+    header + all_coords
 }
 
 /// Write a Rect geometry to a Writer encoded as WKB
+///
+/// Note that only 2D Rects are supported. Even if the input Rect has more than 2 dimensions, only
+/// the X and Y dimensions will be written.
 pub fn write_rect(
     writer: &mut impl Write,
     geom: &impl RectTrait<T = f64>,
     options: &WriteOptions,
 ) -> WkbResult<()> {
-    write_polygon(writer, &RectWrapper(geom), options)
-}
+    // Byte order
+    writer.write_u8(options.endianness.into())?;
 
-impl<'a, G: RectTrait<T = f64>> GeometryTrait for RectWrapper<'a, G> {
-    type T = f64;
-    type PointType<'b>
-        = UnimplementedPoint<f64>
-    where
-        Self: 'b;
-    type LineStringType<'b>
-        = UnimplementedLineString<f64>
-    where
-        Self: 'b;
-    type PolygonType<'b>
-        = Self
-    where
-        Self: 'b;
-    type MultiPointType<'b>
-        = UnimplementedMultiPoint<f64>
-    where
-        Self: 'b;
-    type MultiLineStringType<'b>
-        = UnimplementedMultiLineString<f64>
-    where
-        Self: 'b;
-    type MultiPolygonType<'b>
-        = UnimplementedMultiPolygon<f64>
-    where
-        Self: 'b;
-    type GeometryCollectionType<'b>
-        = UnimplementedGeometryCollection<f64>
-    where
-        Self: 'b;
-    type RectType<'b>
-        = UnimplementedRect<f64>
-    where
-        Self: 'b;
-    type LineType<'b>
-        = UnimplementedLine<f64>
-    where
-        Self: 'b;
-    type TriangleType<'b>
-        = UnimplementedTriangle<f64>
-    where
-        Self: 'b;
-
-    fn dim(&self) -> geo_traits::Dimensions {
-        geo_traits::Dimensions::Xy
-    }
-
-    fn as_type(
-        &self,
-    ) -> geo_traits::GeometryType<
-        '_,
-        Self::PointType<'a>,
-        Self::LineStringType<'a>,
-        Self::PolygonType<'a>,
-        Self::MultiPointType<'a>,
-        Self::MultiLineStringType<'a>,
-        Self::MultiPolygonType<'a>,
-        Self::GeometryCollectionType<'a>,
-        Self::RectType<'_>,
-        Self::TriangleType<'_>,
-        Self::LineType<'_>,
-    > {
-        geo_traits::GeometryType::Polygon(self)
+    // Content
+    match options.endianness {
+        Endianness::LittleEndian => write_rect_content::<LittleEndian>(writer, geom),
+        Endianness::BigEndian => write_rect_content::<BigEndian>(writer, geom),
     }
 }
 
-impl<'a, G: RectTrait<T = f64>> GeometryTrait for &'a RectWrapper<'a, G> {
-    type T = f64;
-    type PointType<'b>
-        = UnimplementedPoint<f64>
-    where
-        Self: 'b;
-    type LineStringType<'b>
-        = Self
-    where
-        Self: 'b;
-    type PolygonType<'b>
-        = UnimplementedPolygon<f64>
-    where
-        Self: 'b;
-    type MultiPointType<'b>
-        = UnimplementedMultiPoint<f64>
-    where
-        Self: 'b;
-    type MultiLineStringType<'b>
-        = UnimplementedMultiLineString<f64>
-    where
-        Self: 'b;
-    type MultiPolygonType<'b>
-        = UnimplementedMultiPolygon<f64>
-    where
-        Self: 'b;
-    type GeometryCollectionType<'b>
-        = UnimplementedGeometryCollection<f64>
-    where
-        Self: 'b;
-    type RectType<'b>
-        = UnimplementedRect<f64>
-    where
-        Self: 'b;
-    type LineType<'b>
-        = UnimplementedLine<f64>
-    where
-        Self: 'b;
-    type TriangleType<'b>
-        = UnimplementedTriangle<f64>
-    where
-        Self: 'b;
+/// Minimal struct to hold a named coordinate pair
+struct Coord {
+    x: f64,
+    y: f64,
+}
 
-    fn dim(&self) -> geo_traits::Dimensions {
-        geo_traits::Dimensions::Xy
-    }
+fn write_rect_content<B: ByteOrder>(
+    writer: &mut impl Write,
+    geom: &impl RectTrait<T = f64>,
+) -> WkbResult<()> {
+    let wkb_type = WkbType::Polygon(geom.dim().try_into()?);
+    writer.write_u32::<B>(wkb_type.into())?;
 
-    fn as_type(
-        &self,
-    ) -> geo_traits::GeometryType<
-        '_,
-        Self::PointType<'a>,
-        Self::LineStringType<'a>,
-        Self::PolygonType<'a>,
-        Self::MultiPointType<'a>,
-        Self::MultiLineStringType<'a>,
-        Self::MultiPolygonType<'a>,
-        Self::GeometryCollectionType<'a>,
-        Self::RectType<'_>,
-        Self::TriangleType<'_>,
-        Self::LineType<'_>,
-    > {
-        geo_traits::GeometryType::LineString(self)
-    }
+    // numRings
+    let num_rings = 1;
+    writer.write_u32::<B>(num_rings)?;
+
+    let min_coord = geom.min();
+    let max_coord = geom.max();
+
+    let ll = Coord {
+        x: min_coord.x(),
+        y: min_coord.y(),
+    };
+    let ul = Coord {
+        x: min_coord.x(),
+        y: max_coord.y(),
+    };
+    let ur = Coord {
+        x: max_coord.x(),
+        y: max_coord.y(),
+    };
+    let lr = Coord {
+        x: max_coord.x(),
+        y: min_coord.y(),
+    };
+
+    writer.write_f64::<B>(ll.x)?;
+    writer.write_f64::<B>(ll.y)?;
+
+    writer.write_f64::<B>(ul.x)?;
+    writer.write_f64::<B>(ul.y)?;
+
+    writer.write_f64::<B>(ur.x)?;
+    writer.write_f64::<B>(ur.y)?;
+
+    writer.write_f64::<B>(lr.x)?;
+    writer.write_f64::<B>(lr.y)?;
+
+    writer.write_f64::<B>(ll.x)?;
+    writer.write_f64::<B>(ll.y)?;
+
+    Ok(())
 }

--- a/src/writer/triangle.rs
+++ b/src/writer/triangle.rs
@@ -1,62 +1,18 @@
-use std::io::Write;
-
-use geo_traits::{
-    GeometryTrait, LineStringTrait, PolygonTrait, TriangleTrait, UnimplementedGeometryCollection,
-    UnimplementedLine, UnimplementedLineString, UnimplementedMultiLineString,
-    UnimplementedMultiPoint, UnimplementedMultiPolygon, UnimplementedPoint, UnimplementedPolygon,
-    UnimplementedRect, UnimplementedTriangle,
-};
-
+use crate::common::WkbType;
 use crate::error::WkbResult;
-use crate::writer::{polygon_wkb_size, write_polygon, WriteOptions};
-
-/// A wrapper around an impl TriangleTrait to provide LineStringTrait and PolygonTrait
-struct TriangleWrapper<'a, G: TriangleTrait<T = f64>>(&'a G);
-
-impl<'a, G: TriangleTrait<T = f64>> LineStringTrait for &'a TriangleWrapper<'a, G> {
-    type CoordType<'b>
-        = G::CoordType<'a>
-    where
-        G: 'b,
-        Self: 'b;
-
-    fn num_coords(&self) -> usize {
-        3
-    }
-
-    unsafe fn coord_unchecked(&self, i: usize) -> Self::CoordType<'_> {
-        match i {
-            0 => self.0.first(),
-            1 => self.0.second(),
-            2 => self.0.third(),
-            _ => unreachable!(),
-        }
-    }
-}
-
-impl<G: TriangleTrait<T = f64>> PolygonTrait for TriangleWrapper<'_, G> {
-    type RingType<'b>
-        = &'b TriangleWrapper<'b, G>
-    where
-        G: 'b,
-        Self: 'b;
-
-    fn exterior(&self) -> Option<Self::RingType<'_>> {
-        Some(self)
-    }
-
-    fn num_interiors(&self) -> usize {
-        0
-    }
-
-    unsafe fn interior_unchecked(&self, _i: usize) -> Self::RingType<'_> {
-        unreachable!()
-    }
-}
+use crate::writer::coord::write_coord;
+use crate::writer::WriteOptions;
+use crate::Endianness;
+use byteorder::{BigEndian, ByteOrder, LittleEndian, WriteBytesExt};
+use geo_traits::TriangleTrait;
+use std::io::Write;
 
 /// The number of bytes this Triangle will take up when encoded as WKB
 pub fn triangle_wkb_size(geom: &impl TriangleTrait<T = f64>) -> usize {
-    polygon_wkb_size(&TriangleWrapper(geom))
+    let header = 1 + 4 + 4;
+    let each_coord = geom.dim().size() * 8;
+    let all_coords = 4 * each_coord;
+    header + all_coords
 }
 
 /// Write a Triangle geometry to a Writer encoded as WKB
@@ -65,137 +21,34 @@ pub fn write_triangle(
     geom: &impl TriangleTrait<T = f64>,
     options: &WriteOptions,
 ) -> WkbResult<()> {
-    write_polygon(writer, &TriangleWrapper(geom), options)
-}
+    // Byte order
+    writer.write_u8(options.endianness.into())?;
 
-impl<G: TriangleTrait<T = f64>> GeometryTrait for TriangleWrapper<'_, G> {
-    type T = f64;
-    type PointType<'b>
-        = UnimplementedPoint<f64>
-    where
-        Self: 'b;
-    type LineStringType<'b>
-        = UnimplementedLineString<f64>
-    where
-        Self: 'b;
-    type PolygonType<'b>
-        = Self
-    where
-        Self: 'b;
-    type MultiPointType<'b>
-        = UnimplementedMultiPoint<f64>
-    where
-        Self: 'b;
-    type MultiLineStringType<'b>
-        = UnimplementedMultiLineString<f64>
-    where
-        Self: 'b;
-    type MultiPolygonType<'b>
-        = UnimplementedMultiPolygon<f64>
-    where
-        Self: 'b;
-    type GeometryCollectionType<'b>
-        = UnimplementedGeometryCollection<f64>
-    where
-        Self: 'b;
-    type RectType<'b>
-        = UnimplementedRect<f64>
-    where
-        Self: 'b;
-    type LineType<'b>
-        = UnimplementedLine<f64>
-    where
-        Self: 'b;
-    type TriangleType<'b>
-        = UnimplementedTriangle<f64>
-    where
-        Self: 'b;
-
-    fn dim(&self) -> geo_traits::Dimensions {
-        geo_traits::Dimensions::Xy
-    }
-
-    fn as_type(
-        &self,
-    ) -> geo_traits::GeometryType<
-        '_,
-        Self::PointType<'_>,
-        Self::LineStringType<'_>,
-        Self::PolygonType<'_>,
-        Self::MultiPointType<'_>,
-        Self::MultiLineStringType<'_>,
-        Self::MultiPolygonType<'_>,
-        Self::GeometryCollectionType<'_>,
-        Self::RectType<'_>,
-        Self::TriangleType<'_>,
-        Self::LineType<'_>,
-    > {
-        geo_traits::GeometryType::Polygon(self)
+    // Content
+    match options.endianness {
+        Endianness::LittleEndian => write_triangle_content::<LittleEndian>(writer, geom),
+        Endianness::BigEndian => write_triangle_content::<BigEndian>(writer, geom),
     }
 }
 
-impl<'a, G: TriangleTrait<T = f64>> GeometryTrait for &'a TriangleWrapper<'a, G> {
-    type T = f64;
-    type PointType<'b>
-        = UnimplementedPoint<f64>
-    where
-        Self: 'b;
-    type LineStringType<'b>
-        = Self
-    where
-        Self: 'b;
-    type PolygonType<'b>
-        = UnimplementedPolygon<f64>
-    where
-        Self: 'b;
-    type MultiPointType<'b>
-        = UnimplementedMultiPoint<f64>
-    where
-        Self: 'b;
-    type MultiLineStringType<'b>
-        = UnimplementedMultiLineString<f64>
-    where
-        Self: 'b;
-    type MultiPolygonType<'b>
-        = UnimplementedMultiPolygon<f64>
-    where
-        Self: 'b;
-    type GeometryCollectionType<'b>
-        = UnimplementedGeometryCollection<f64>
-    where
-        Self: 'b;
-    type RectType<'b>
-        = UnimplementedRect<f64>
-    where
-        Self: 'b;
-    type LineType<'b>
-        = UnimplementedLine<f64>
-    where
-        Self: 'b;
-    type TriangleType<'b>
-        = UnimplementedTriangle<f64>
-    where
-        Self: 'b;
+fn write_triangle_content<B: ByteOrder>(
+    writer: &mut impl Write,
+    geom: &impl TriangleTrait<T = f64>,
+) -> WkbResult<()> {
+    let wkb_type = WkbType::Polygon(geom.dim().try_into()?);
+    writer.write_u32::<B>(wkb_type.into())?;
 
-    fn dim(&self) -> geo_traits::Dimensions {
-        geo_traits::Dimensions::Xy
-    }
+    // numRings
+    let num_rings = 1;
+    writer.write_u32::<B>(num_rings)?;
 
-    fn as_type(
-        &self,
-    ) -> geo_traits::GeometryType<
-        '_,
-        Self::PointType<'_>,
-        Self::LineStringType<'_>,
-        Self::PolygonType<'_>,
-        Self::MultiPointType<'_>,
-        Self::MultiLineStringType<'_>,
-        Self::MultiPolygonType<'_>,
-        Self::GeometryCollectionType<'_>,
-        Self::RectType<'_>,
-        Self::TriangleType<'_>,
-        Self::LineType<'_>,
-    > {
-        geo_traits::GeometryType::LineString(self)
-    }
+    let num_coords = 4;
+    writer.write_u32::<B>(num_coords)?;
+
+    write_coord::<B>(writer, &geom.first())?;
+    write_coord::<B>(writer, &geom.second())?;
+    write_coord::<B>(writer, &geom.third())?;
+    write_coord::<B>(writer, &geom.first())?;
+
+    Ok(())
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
- [x] I ran cargo fmt
---

Rust 1.90 caused a regression in release mode for consumers of the `geoarrow-array` crate: https://github.com/geoarrow/geoarrow-rs/issues/1339, https://github.com/rust-lang/rust/issues/131960. This code compiled fine in 1.89 but no longer compiles in 1.90 in release mode. (It compiles in debug mode)

I tracked this down to the trait wrappers implemented here. If you pull main of `geoarrow-rs` (https://github.com/geoarrow/geoarrow-rs/commit/338a08cd2f5f2b35df36453ec3ad6ef031dfb702) and run `cargo +1.90 build --release -p geoarrow-array` you get a compiler error. If you check out the branch in https://github.com/geoarrow/geoarrow-rs/pull/1341 you no longer get a compiler error.

Perhaps we should add some docs to the code to explain why we're not using trait wrappers? Then again, this implementation is so simple that I almost think I should've used this from the start.