### PR TITLE
Expose `Dimension` publicly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix CI by removing georust container & fix clippy lint (#78)
 - Add lint warning for missing docs #80
 - Remove unnecessary `unwrap`s #79
+- Expose `Dimension` publicly #82
 
 ## 0.9.0 - 2025-05-14
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,4 +14,4 @@ pub mod reader;
 mod test;
 pub mod writer;
 
-pub use common::{Dimension, Endianness};
+pub use common::Endianness;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,4 +7,4 @@ pub mod reader;
 mod test;
 pub mod writer;
 
-pub use common::Endianness;
+pub use common::{Dimension, Endianness};

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -15,6 +15,7 @@ mod point;
 mod polygon;
 mod util;
 
+pub use crate::common::Dimension;
 pub use geometry::Wkb;
 use geometry_collection::GeometryCollection;
 use linestring::LineString;


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
- [x] I ran cargo fmt
---

Closes https://github.com/georust/wkb/issues/73

Exposes the `Dimension` enum as `wkb::reader::Dimension`. This is only relevant to reader code as write APIs will access the dimension from geo-traits