### PR TITLE
Expose APIs for accessing the underlying WKB buffer to implement various functions efficiently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Expose APIs for accessing the underlying WKB buffer. (#85)
+- Making structs for individual geometry types public. (#85)
+
 ## 0.9.1 - 2025-09-24
 
 - Don't panic when parsing invalid WKB (#74).

--- a/src/common.rs
+++ b/src/common.rs
@@ -200,7 +200,7 @@ impl From<WkbType> for u32 {
 }
 
 /// Endianness
-#[derive(Debug, Clone, Copy, Default, TryFromPrimitive, IntoPrimitive)]
+#[derive(Debug, Clone, Copy, Default, TryFromPrimitive, IntoPrimitive, PartialEq)]
 #[repr(u8)]
 pub enum Endianness {
     /// Big endian

--- a/src/reader/coord.rs
+++ b/src/reader/coord.rs
@@ -66,6 +66,27 @@ impl<'a> Coord<'a> {
         reader.read_f64(self.byte_order).unwrap()
     }
 
+    /// Get the byte order of WKB coordinate
+    #[inline]
+    pub fn byte_order(&self) -> Endianness {
+        self.byte_order
+    }
+
+    /// Get the slice of bytes containing the coordinate. The byte order
+    /// of coordinate can be obtained by calling [Coord::byte_order].
+    #[inline]
+    pub fn coord_slice(&self) -> &'a [u8] {
+        let start = self.offset as usize;
+        let end = start + self.size() as usize;
+        &self.buf[start..end]
+    }
+
+    /// Get the dimension of this coordinate
+    #[inline]
+    pub fn dimension(&self) -> Dimension {
+        self.dim
+    }
+
     /// The number of bytes in this object
     ///
     /// Note that this is not the same as the length of the underlying buffer

--- a/src/reader/geometry_collection.rs
+++ b/src/reader/geometry_collection.rs
@@ -23,7 +23,11 @@ impl<'a> GeometryCollection<'a> {
     /// Construct a new GeometryCollection from a WKB buffer.
     ///
     /// This will parse the WKB header and extract all contained geometries.
-    pub fn try_new(buf: &'a [u8], byte_order: Endianness, dim: Dimension) -> WkbResult<Self> {
+    pub(crate) fn try_new(
+        buf: &'a [u8],
+        byte_order: Endianness,
+        dim: Dimension,
+    ) -> WkbResult<Self> {
         let mut offset = 0;
         let has_srid = has_srid(buf, byte_order, offset)?;
         if has_srid {

--- a/src/reader/geometry_collection.rs
+++ b/src/reader/geometry_collection.rs
@@ -20,6 +20,9 @@ pub struct GeometryCollection<'a> {
 }
 
 impl<'a> GeometryCollection<'a> {
+    /// Construct a new GeometryCollection from a WKB buffer.
+    ///
+    /// This will parse the WKB header and extract all contained geometries.
     pub fn try_new(buf: &'a [u8], byte_order: Endianness, dim: Dimension) -> WkbResult<Self> {
         let mut offset = 0;
         let has_srid = has_srid(buf, byte_order, offset)?;
@@ -56,10 +59,14 @@ impl<'a> GeometryCollection<'a> {
         })
     }
 
+    /// The dimension of this GeometryCollection
     pub fn dimension(&self) -> Dimension {
         self.dim
     }
 
+    /// The number of bytes in this object, including any header
+    ///
+    /// Note that this is not the same as the length of the underlying buffer
     pub fn size(&self) -> u64 {
         // - 1: byteOrder
         // - 4: wkbType

--- a/src/reader/linearring.rs
+++ b/src/reader/linearring.rs
@@ -40,10 +40,19 @@ pub struct LinearRing<'a> {
 }
 
 impl<'a> LinearRing<'a> {
+    /// Construct a new LinearRing from a WKB buffer.
+    ///
+    /// # Panics
+    ///
+    /// This will panic if the WKB buffer is invalid. For fallible parsing, use
+    /// [`try_new`](Self::try_new) instead.
     pub fn new(buf: &'a [u8], byte_order: Endianness, offset: u64, dim: Dimension) -> Self {
         Self::try_new(buf, byte_order, offset, dim).unwrap()
     }
 
+    /// Construct a new LinearRing from a WKB buffer.
+    ///
+    /// This will parse the number of points and validate the buffer length.
     pub fn try_new(
         buf: &'a [u8],
         byte_order: Endianness,
@@ -101,8 +110,25 @@ impl<'a> LinearRing<'a> {
         self.offset + 4 + (self.dim.size() as u64 * 8 * i)
     }
 
-    pub(crate) fn dimension(&self) -> Dimension {
+    /// The dimension of this LinearRing
+    #[inline]
+    pub fn dimension(&self) -> Dimension {
         self.dim
+    }
+
+    /// The slice of bytes containing the coordinates of this LinearRing. The byte order
+    /// of LinearRing can be obtained by calling [LinearRing::byte_order].
+    #[inline]
+    pub fn coords_slice(&self) -> &'a [u8] {
+        let start = self.coord_offset(0) as usize;
+        let end = start + self.dim.size() * 8 * self.num_points;
+        &self.buf[start..end]
+    }
+
+    /// Get the byte order of WKB LinearRing
+    #[inline]
+    pub fn byte_order(&self) -> Endianness {
+        self.byte_order
     }
 }
 

--- a/src/reader/linearring.rs
+++ b/src/reader/linearring.rs
@@ -42,18 +42,8 @@ pub struct LinearRing<'a> {
 impl<'a> LinearRing<'a> {
     /// Construct a new LinearRing from a WKB buffer.
     ///
-    /// # Panics
-    ///
-    /// This will panic if the WKB buffer is invalid. For fallible parsing, use
-    /// [`try_new`](Self::try_new) instead.
-    pub fn new(buf: &'a [u8], byte_order: Endianness, offset: u64, dim: Dimension) -> Self {
-        Self::try_new(buf, byte_order, offset, dim).unwrap()
-    }
-
-    /// Construct a new LinearRing from a WKB buffer.
-    ///
     /// This will parse the number of points and validate the buffer length.
-    pub fn try_new(
+    pub(crate) fn try_new(
         buf: &'a [u8],
         byte_order: Endianness,
         offset: u64,

--- a/src/reader/linestring.rs
+++ b/src/reader/linestring.rs
@@ -30,18 +30,8 @@ pub struct LineString<'a> {
 impl<'a> LineString<'a> {
     /// Construct a new LineString from a WKB buffer.
     ///
-    /// # Panics
-    ///
-    /// This will panic if the WKB buffer is invalid. For fallible parsing, use
-    /// [`try_new`](Self::try_new) instead.
-    pub fn new(buf: &'a [u8], byte_order: Endianness, offset: u64, dim: Dimension) -> Self {
-        Self::try_new(buf, byte_order, offset, dim).unwrap()
-    }
-
-    /// Construct a new LineString from a WKB buffer.
-    ///
     /// This will parse the WKB header and validate the buffer length.
-    pub fn try_new(
+    pub(crate) fn try_new(
         buf: &'a [u8],
         byte_order: Endianness,
         mut offset: u64,

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -16,14 +16,16 @@ mod polygon;
 mod util;
 
 pub use crate::common::Dimension;
+pub use coord::Coord;
 pub use geometry::Wkb;
-use geometry_collection::GeometryCollection;
-use linestring::LineString;
-use multilinestring::MultiLineString;
-use multipoint::MultiPoint;
-use multipolygon::MultiPolygon;
-use point::Point;
-use polygon::Polygon;
+pub use geometry_collection::GeometryCollection;
+pub use linearring::LinearRing;
+pub use linestring::LineString;
+pub use multilinestring::MultiLineString;
+pub use multipoint::MultiPoint;
+pub use multipolygon::MultiPolygon;
+pub use point::Point;
+pub use polygon::Polygon;
 
 use crate::error::WkbResult;
 

--- a/src/reader/multilinestring.rs
+++ b/src/reader/multilinestring.rs
@@ -83,6 +83,7 @@ impl<'a> MultiLineString<'a> {
             .fold(header, |acc, ls| acc + ls.size())
     }
 
+    /// The dimension of this MultiLineString
     pub fn dimension(&self) -> Dimension {
         self.dim
     }

--- a/src/reader/multilinestring.rs
+++ b/src/reader/multilinestring.rs
@@ -21,11 +21,6 @@ pub struct MultiLineString<'a> {
 }
 
 impl<'a> MultiLineString<'a> {
-    #[allow(dead_code)]
-    pub(crate) fn new(buf: &'a [u8], byte_order: Endianness, dim: Dimension) -> Self {
-        Self::try_new(buf, byte_order, dim).unwrap()
-    }
-
     pub(crate) fn try_new(
         buf: &'a [u8],
         byte_order: Endianness,

--- a/src/reader/multipoint.rs
+++ b/src/reader/multipoint.rs
@@ -97,6 +97,7 @@ impl<'a> MultiPoint<'a> {
         header + ((1 + 4 + (self.dim.size() as u64 * 8)) * i)
     }
 
+    /// The dimension of this MultiPoint
     pub fn dimension(&self) -> Dimension {
         self.dim
     }

--- a/src/reader/multipoint.rs
+++ b/src/reader/multipoint.rs
@@ -22,11 +22,6 @@ pub struct MultiPoint<'a> {
 }
 
 impl<'a> MultiPoint<'a> {
-    #[allow(dead_code)]
-    pub(crate) fn new(buf: &'a [u8], byte_order: Endianness, dim: Dimension) -> Self {
-        Self::try_new(buf, byte_order, dim).unwrap()
-    }
-
     pub(crate) fn try_new(
         buf: &'a [u8],
         byte_order: Endianness,

--- a/src/reader/multipolygon.rs
+++ b/src/reader/multipolygon.rs
@@ -21,11 +21,6 @@ pub struct MultiPolygon<'a> {
 }
 
 impl<'a> MultiPolygon<'a> {
-    #[allow(dead_code)]
-    pub(crate) fn new(buf: &'a [u8], byte_order: Endianness, dim: Dimension) -> Self {
-        Self::try_new(buf, byte_order, dim).unwrap()
-    }
-
     pub(crate) fn try_new(
         buf: &'a [u8],
         byte_order: Endianness,

--- a/src/reader/multipolygon.rs
+++ b/src/reader/multipolygon.rs
@@ -82,6 +82,7 @@ impl<'a> MultiPolygon<'a> {
             .fold(header, |acc, x| acc + x.size())
     }
 
+    /// The dimension of this MultiPolygon
     pub fn dimension(&self) -> Dimension {
         self.dim
     }

--- a/src/reader/point.rs
+++ b/src/reader/point.rs
@@ -88,8 +88,29 @@ impl<'a> Point<'a> {
         header + (self.dim.size() as u64 * 8)
     }
 
+    /// The dimension of this Point
+    #[inline]
     pub fn dimension(&self) -> Dimension {
         self.dim
+    }
+
+    /// Whether this Point is empty
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.is_empty
+    }
+
+    /// Get the byte order of WKB point
+    #[inline]
+    pub fn byte_order(&self) -> Endianness {
+        self.coord.byte_order()
+    }
+
+    /// Get the slice of bytes containing the coordinate. The byte order
+    /// of coordinate can be obtained by calling [Point::byte_order].
+    #[inline]
+    pub fn coord_slice(&self) -> &'a [u8] {
+        self.coord.coord_slice()
     }
 }
 

--- a/src/reader/polygon.rs
+++ b/src/reader/polygon.rs
@@ -23,18 +23,8 @@ pub struct Polygon<'a> {
 impl<'a> Polygon<'a> {
     /// Construct a new Polygon from a WKB buffer.
     ///
-    /// # Panics
-    ///
-    /// This will panic if the WKB buffer is invalid. For fallible parsing, use
-    /// [`try_new`](Self::try_new) instead.
-    pub fn new(buf: &'a [u8], byte_order: Endianness, offset: u64, dim: Dimension) -> Self {
-        Self::try_new(buf, byte_order, offset, dim).unwrap()
-    }
-
-    /// Construct a new Polygon from a WKB buffer.
-    ///
     /// This will parse the WKB header and extract all linear rings.
-    pub fn try_new(
+    pub(crate) fn try_new(
         buf: &'a [u8],
         byte_order: Endianness,
         mut offset: u64,

--- a/src/reader/polygon.rs
+++ b/src/reader/polygon.rs
@@ -21,10 +21,19 @@ pub struct Polygon<'a> {
 }
 
 impl<'a> Polygon<'a> {
+    /// Construct a new Polygon from a WKB buffer.
+    ///
+    /// # Panics
+    ///
+    /// This will panic if the WKB buffer is invalid. For fallible parsing, use
+    /// [`try_new`](Self::try_new) instead.
     pub fn new(buf: &'a [u8], byte_order: Endianness, offset: u64, dim: Dimension) -> Self {
         Self::try_new(buf, byte_order, offset, dim).unwrap()
     }
 
+    /// Construct a new Polygon from a WKB buffer.
+    ///
+    /// This will parse the WKB header and extract all linear rings.
     pub fn try_new(
         buf: &'a [u8],
         byte_order: Endianness,
@@ -81,6 +90,7 @@ impl<'a> Polygon<'a> {
             .fold(header, |acc, ring| acc + ring.size())
     }
 
+    /// The dimension of this Polygon
     pub fn dimension(&self) -> Dimension {
         self.dim
     }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
- [x] I ran cargo fmt
---

This work originates from [SedonaDB](https://github.com/apache/sedona-db). We have implemented a fast WKB to GEOS geometry conversion function in our own fork of wkb: https://github.com/wherobots/wkb/pull/2, which requires access to the underlying WKB buffer and structs defined for individual geometry types. Having access to these implementation details allows us to make this particular task 4 times faster.

I believe that there might be other scenarios where having access to the raw WKB buffer will help a lot, so I added several methods for exposing slices of WKB buffers and some metadata about the encoded coordinates.